### PR TITLE
fix: Xss Sanitization for UniSaarApp

### DIFF
--- a/server/src/services/article_scraper.py
+++ b/server/src/services/article_scraper.py
@@ -87,7 +87,10 @@ class _Sanitizer(_StdParser):
 
         if tag == "img":
             src = attr.get("src", "") or ""
-            if not src or src.startswith("data:"):
+            # Security fix: normalize src to lowercase and strip whitespace
+            # to prevent XSS bypass via case/whitespace in URI schemes.
+            src_normalized = src.strip().lower()
+            if not src or src_normalized.startswith(("data:", "javascript:", "vbscript:")):
                 self._skip_depth = 1
                 return
             if src.startswith("/"):
@@ -101,7 +104,10 @@ class _Sanitizer(_StdParser):
 
         if tag == "a":
             href = attr.get("href", "") or ""
-            if href.startswith("javascript:") or href.startswith("data:"):
+            # Security fix: normalize href to lowercase and strip whitespace
+            # to prevent XSS bypass via case/whitespace in URI schemes.
+            href_normalized = href.strip().lower()
+            if href_normalized.startswith(("javascript:", "data:", "vbscript:")):
                 self._skip_depth = 1
                 return
             if href.startswith("/"):


### PR DESCRIPTION
Hey there! 👋

I was reviewing the codebase and noticed a potential security issue that I thought I'd flag and fix.

## What I found

- **[HIGH] xss** in `server/src/services/article_scraper.py`: The HTML sanitizer uses case-sensitive and whitespace-sensitive prefix checks to block dangerous URI schemes like `javas

## What I changed

The fix is minimal and targeted — I added proper validation/sanitization where user-controlled or untrusted data enters sensitive operations. No changes to existing functionality or public APIs.

## Testing

Ran the existing test suite locally, everything passes. The change is backward-compatible.

Happy to discuss if you have questions!

Relates to: https://github.com/Ali-Alhasani/UniSaarApp/issues/30

---
💛 If this fix helps, donations are appreciated (ETH/ERC-20): `0x1478f1BDEACc7b434b4405350A15993cDcddc79F` ([Etherscan](https://etherscan.io/address/0x1478f1BDEACc7b434b4405350A15993cDcddc79F))