### PR TITLE
server: fix meal detail ignoring campus location

### DIFF
--- a/server/.gitignore
+++ b/server/.gitignore
@@ -24,3 +24,5 @@ venv/
 
 # Pre-commit
 .pre-commit-cache/
+.DS_Store
+.idea/

--- a/server/src/api/mensa.py
+++ b/server/src/api/mensa.py
@@ -4,8 +4,9 @@ from fastapi import APIRouter
 from fastapi.responses import JSONResponse, Response
 
 from src.api._responses import cache_not_ready
-from src.core.enums import Language, MensaLocation
+from src.core.enums import CampusLocation, Language
 from src.core.locale import MEAL_NOT_FOUND
+from src.core.meal_id import MealId, campus_from_id
 from src.core.routes import Route
 from src.models.mensa import MensaFilters, MensaInfo, MensaMenu
 from src.storage import cache_keys
@@ -16,7 +17,7 @@ router = APIRouter()
 
 @router.get(Route.MENSA_MAIN_SCREEN)
 async def get_mensa_menu(
-    location: MensaLocation = MensaLocation.SB, language: Language = Language.DE
+    location: CampusLocation = CampusLocation.SB, language: Language = Language.DE
 ) -> Response:
     menu = await cache.get_model(cache_keys.mensa_menu(location, language), MensaMenu)
     if menu is None:
@@ -26,11 +27,16 @@ async def get_mensa_menu(
 
 @router.get(Route.MENSA_MEAL_DETAIL)
 async def get_meal_detail(
-    meal: int,
-    location: MensaLocation = MensaLocation.SB,
+    meal: MealId,
     language: Language = Language.DE,
 ) -> Response:
-    meal_map = await cache.get_async(cache_keys.mensa_meal(location, language))
+    try:
+        campus = campus_from_id(meal)
+    except ValueError:
+        return Response(
+            status_code=404, content=MEAL_NOT_FOUND[language], media_type="text/plain"
+        )
+    meal_map = await cache.get_async(cache_keys.mensa_meal(campus, language))
     if meal_map is None:
         return cache_not_ready(language)
     detail = meal_map.get(str(meal))
@@ -43,7 +49,7 @@ async def get_meal_detail(
 
 @router.get(Route.MENSA_INFO)
 async def get_mensa_info(
-    location: MensaLocation = MensaLocation.SB, language: Language = Language.DE
+    location: CampusLocation = CampusLocation.SB, language: Language = Language.DE
 ) -> Response:
     info = await cache.get_model(cache_keys.mensa_info(location, language), MensaInfo)
     if info is None:

--- a/server/src/cli.py
+++ b/server/src/cli.py
@@ -25,7 +25,10 @@ import diskcache
 from loguru import logger
 
 from src.core.config import settings
-from src.core.constants import MENSA_LANGUAGES, MENSA_LOCATIONS, NEWSFEED_LANGUAGES
+from src.core.constants import (
+    MENSA_CAMPUS_LOCATIONS,
+    SUPPORTED_LANGUAGES,
+)
 from src.storage import cache_keys
 
 # ---------------------------------------------------------------------------
@@ -42,25 +45,25 @@ _SCHEDULER_KEYS = [
 
 _DATA_KEYS: list[str] = (
     [cache_keys.campus_map()]
-    + [cache_keys.news(lang) for lang in NEWSFEED_LANGUAGES]
-    + [cache_keys.events(lang) for lang in NEWSFEED_LANGUAGES]
-    + [cache_keys.helpful_numbers(lang) for lang in NEWSFEED_LANGUAGES]
-    + [cache_keys.more(lang) for lang in NEWSFEED_LANGUAGES]
+    + [cache_keys.news(lang) for lang in SUPPORTED_LANGUAGES]
+    + [cache_keys.events(lang) for lang in SUPPORTED_LANGUAGES]
+    + [cache_keys.helpful_numbers(lang) for lang in SUPPORTED_LANGUAGES]
+    + [cache_keys.more(lang) for lang in SUPPORTED_LANGUAGES]
     + [
-        cache_keys.mensa_menu(loc, lang)
-        for loc in MENSA_LOCATIONS
-        for lang in MENSA_LANGUAGES
+        cache_keys.mensa_menu(campus, lang)
+        for campus in MENSA_CAMPUS_LOCATIONS
+        for lang in SUPPORTED_LANGUAGES
     ]
     + [
-        cache_keys.mensa_meal(loc, lang)
-        for loc in MENSA_LOCATIONS
-        for lang in MENSA_LANGUAGES
+        cache_keys.mensa_meal(campus, lang)
+        for campus in MENSA_CAMPUS_LOCATIONS
+        for lang in SUPPORTED_LANGUAGES
     ]
-    + [cache_keys.mensa_filters(lang) for lang in MENSA_LANGUAGES]
+    + [cache_keys.mensa_filters(lang) for lang in SUPPORTED_LANGUAGES]
     + [
-        cache_keys.mensa_info(loc, lang)
-        for loc in MENSA_LOCATIONS
-        for lang in MENSA_LANGUAGES
+        cache_keys.mensa_info(campus, lang)
+        for campus in MENSA_CAMPUS_LOCATIONS
+        for lang in SUPPORTED_LANGUAGES
     ]
 )
 
@@ -69,32 +72,32 @@ ALL_EXPECTED_KEYS = _SCHEDULER_KEYS + _DATA_KEYS
 # Keys that belong to each job — used by `clear --job`
 _JOB_KEYS: dict[str, list[str]] = {
     "news": (
-        [cache_keys.news(lang) for lang in NEWSFEED_LANGUAGES]
-        + [cache_keys.events(lang) for lang in NEWSFEED_LANGUAGES]
+        [cache_keys.news(lang) for lang in SUPPORTED_LANGUAGES]
+        + [cache_keys.events(lang) for lang in SUPPORTED_LANGUAGES]
         + [cache_keys.scheduler_last_run("news")]
     ),
     "mensa": (
         [
-            cache_keys.mensa_menu(loc, lang)
-            for loc in MENSA_LOCATIONS
-            for lang in MENSA_LANGUAGES
+            cache_keys.mensa_menu(campus, lang)
+            for campus in MENSA_CAMPUS_LOCATIONS
+            for lang in SUPPORTED_LANGUAGES
         ]
         + [
-            cache_keys.mensa_meal(loc, lang)
-            for loc in MENSA_LOCATIONS
-            for lang in MENSA_LANGUAGES
+            cache_keys.mensa_meal(campus, lang)
+            for campus in MENSA_CAMPUS_LOCATIONS
+            for lang in SUPPORTED_LANGUAGES
         ]
-        + [cache_keys.mensa_filters(lang) for lang in MENSA_LANGUAGES]
+        + [cache_keys.mensa_filters(lang) for lang in SUPPORTED_LANGUAGES]
         + [
-            cache_keys.mensa_info(loc, lang)
-            for loc in MENSA_LOCATIONS
-            for lang in MENSA_LANGUAGES
+            cache_keys.mensa_info(campus, lang)
+            for campus in MENSA_CAMPUS_LOCATIONS
+            for lang in SUPPORTED_LANGUAGES
         ]
         + [cache_keys.scheduler_last_run("mensa")]
     ),
     "helpful-numbers": (
-        [cache_keys.helpful_numbers(lang) for lang in NEWSFEED_LANGUAGES]
-        + [cache_keys.more(lang) for lang in NEWSFEED_LANGUAGES]
+        [cache_keys.helpful_numbers(lang) for lang in SUPPORTED_LANGUAGES]
+        + [cache_keys.more(lang) for lang in SUPPORTED_LANGUAGES]
         + [cache_keys.scheduler_last_run("helpful_numbers")]
     ),
     "map": [cache_keys.campus_map(), cache_keys.scheduler_last_run("map")],
@@ -200,31 +203,33 @@ def cmd_validate(_args: argparse.Namespace) -> None:
     from src.models.news import NewsFeed
 
     key_model_map: dict[str, Any] = {
-        **{cache_keys.news(lang): NewsFeed for lang in NEWSFEED_LANGUAGES},
-        **{cache_keys.events(lang): EventFeed for lang in NEWSFEED_LANGUAGES},
+        **{cache_keys.news(lang): NewsFeed for lang in SUPPORTED_LANGUAGES},
+        **{cache_keys.events(lang): EventFeed for lang in SUPPORTED_LANGUAGES},
         **{
             cache_keys.helpful_numbers(lang): HelpfulNumbersResponse
-            for lang in NEWSFEED_LANGUAGES
+            for lang in SUPPORTED_LANGUAGES
         },
-        **{cache_keys.more(lang): MoreLinksResponse for lang in NEWSFEED_LANGUAGES},
+        **{cache_keys.more(lang): MoreLinksResponse for lang in SUPPORTED_LANGUAGES},
         **{
-            cache_keys.mensa_menu(loc, lang): MensaMenu
-            for loc in MENSA_LOCATIONS
-            for lang in MENSA_LANGUAGES
+            cache_keys.mensa_menu(campus, lang): MensaMenu
+            for campus in MENSA_CAMPUS_LOCATIONS
+            for lang in SUPPORTED_LANGUAGES
         },
-        **{cache_keys.mensa_filters(lang): MensaFilters for lang in MENSA_LANGUAGES},
         **{
-            cache_keys.mensa_info(loc, lang): MensaInfo
-            for loc in MENSA_LOCATIONS
-            for lang in MENSA_LANGUAGES
+            cache_keys.mensa_filters(lang): MensaFilters for lang in SUPPORTED_LANGUAGES
+        },
+        **{
+            cache_keys.mensa_info(campus, lang): MensaInfo
+            for campus in MENSA_CAMPUS_LOCATIONS
+            for lang in SUPPORTED_LANGUAGES
         },
         cache_keys.campus_map(): MapResponse,
     }
 
     meal_keys = {
-        cache_keys.mensa_meal(loc, lang)
-        for loc in MENSA_LOCATIONS
-        for lang in MENSA_LANGUAGES
+        cache_keys.mensa_meal(campus, lang)
+        for campus in MENSA_CAMPUS_LOCATIONS
+        for lang in SUPPORTED_LANGUAGES
     }
 
     cache = _open_cache()

--- a/server/src/core/constants.py
+++ b/server/src/core/constants.py
@@ -1,21 +1,19 @@
 from __future__ import annotations
 
-from src.core.enums import Language, MensaLocation
+from src.core.enums import CampusLocation, Language, MensaLocation
 
-NEWSFEED_LANGUAGES: list[Language] = [Language.DE, Language.EN, Language.FR]
-MENSA_LANGUAGES: list[Language] = [Language.DE, Language.EN, Language.FR]
-MENSA_LOCATIONS: list[MensaLocation] = [
-    MensaLocation.SB,
-    MensaLocation.HOM,
-    MensaLocation.MENSAGARTEN,
-]
-# Campus locations exposed to iOS clients via /mensa/filters.
-# MENSAGARTEN is scraped internally but not surfaced as a separate picker entry.
-MENSA_CAMPUS_LOCATIONS: list[MensaLocation] = [MensaLocation.SB, MensaLocation.HOM]
-# Maps location shortcodes to display city names.
-CAMPUS_CITY_NAMES: dict[MensaLocation, str] = {
-    MensaLocation.SB: "Saarbrücken",
-    MensaLocation.HOM: "Homburg",
+SUPPORTED_LANGUAGES: list[Language] = [Language.DE, Language.EN, Language.FR]
+
+# All individual mensaar API sources — used by the scraper.
+MENSA_LOCATIONS: list[MensaLocation] = list(MensaLocation)
+
+# Campus-level locations exposed to iOS clients.
+MENSA_CAMPUS_LOCATIONS: list[CampusLocation] = list(CampusLocation)
+
+# Maps campus to display city name.
+CAMPUS_CITY_NAMES: dict[CampusLocation, str] = {
+    CampusLocation.SB: "Saarbrücken",
+    CampusLocation.HOM: "Homburg",
 }
 
 NEWS_URLS: dict[Language, str] = {

--- a/server/src/core/enums.py
+++ b/server/src/core/enums.py
@@ -37,7 +37,7 @@ class MensaLocation(StrEnum):
 
 _MENSA_SOURCE_IDX: dict[MensaLocation, int] = {
     MensaLocation.MENSB: 0,
-    MensaLocation.MENSAGARTEN: 1,
-    MensaLocation.B4R1STA: 2,
+    MensaLocation.B4R1STA: 1,
+    MensaLocation.MENSAGARTEN: 2,
     MensaLocation.MENSHOM: 0,
 }

--- a/server/src/core/enums.py
+++ b/server/src/core/enums.py
@@ -9,7 +9,35 @@ class Language(StrEnum):
     FR = "fr"
 
 
-class MensaLocation(StrEnum):
+class CampusLocation(StrEnum):
     SB = "sb"
     HOM = "hom"
+
+    @property
+    def code(self) -> int:
+        return 1 if self == CampusLocation.SB else 2
+
+
+class MensaLocation(StrEnum):
+    MENSB = "sb"
     MENSAGARTEN = "mensagarten"
+    B4R1STA = "b4r1sta"
+    MENSHOM = "hom"
+
+    @property
+    def campus(self) -> CampusLocation:
+        return (
+            CampusLocation.HOM if self == MensaLocation.MENSHOM else CampusLocation.SB
+        )
+
+    @property
+    def source_idx(self) -> int:
+        return _MENSA_SOURCE_IDX[self]
+
+
+_MENSA_SOURCE_IDX: dict[MensaLocation, int] = {
+    MensaLocation.MENSB: 0,
+    MensaLocation.MENSAGARTEN: 1,
+    MensaLocation.B4R1STA: 2,
+    MensaLocation.MENSHOM: 0,
+}

--- a/server/src/core/locale.py
+++ b/server/src/core/locale.py
@@ -37,9 +37,14 @@ CACHE_NOT_READY: dict[Language, str] = {
     ),
 }
 MEAL_NOT_FOUND: dict[Language, str] = {
-    Language.DE: "Mahlzeitdetails nicht gefunden.",
-    Language.EN: "Meal details not found.",
-    Language.FR: "Détails du repas introuvables.",
+    Language.DE: (
+        "Mahlzeitdetails nicht gefunden."
+        " Bitte aktualisiere dein Menü und versuche es erneut."
+    ),
+    Language.EN: "Meal details not found. Please refresh your feed and try again.",
+    Language.FR: (
+        "Détails du repas introuvables. Veuillez actualiser votre menu et réessayer."
+    ),
 }
 DIRECTORY_QUERY_TOO_SHORT: dict[Language, str] = {
     Language.DE: "Die Suchanfrage muss mindestens 3 Zeichen lang sein.",

--- a/server/src/core/meal_id.py
+++ b/server/src/core/meal_id.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from datetime import date
+from typing import Annotated
+
+from pydantic import Field
+
+from src.core.enums import CampusLocation, MensaLocation
+
+# Derived from enum metadata — update MensaLocation when sources change.
+CAMPUS_SOURCES: dict[CampusLocation, list[MensaLocation]] = {
+    campus: sorted(
+        (s for s in MensaLocation if s.campus == campus),
+        key=lambda s: s.source_idx,
+    )
+    for campus in CampusLocation
+}
+
+
+def generate_meal_id(source: MensaLocation, day: date, counter: int, meal: int) -> int:
+    """Return a stable 14-digit int ID for a meal.
+
+    Format: {campus.code:1}{source.source_idx:1}{YYYYMMDD:8}{counter:02}{meal:02}
+    Same meal always produces the same ID across scrape runs.
+    Raises ValueError if counter or meal exceed 99.
+    """
+    if not (0 <= counter <= 99 and 0 <= meal <= 99):
+        raise ValueError(
+            f"counter and meal must be 0–99, got counter={counter}, meal={meal}"
+        )
+    return int(
+        f"{source.campus.code}{source.source_idx}"
+        f"{day.strftime('%Y%m%d')}{counter:02d}{meal:02d}"
+    )
+
+
+def campus_from_id(meal_id: int) -> CampusLocation:
+    """Extract the CampusLocation encoded in a 14-digit meal ID.
+
+    Raises ValueError for an unrecognised campus code.
+    """
+    campus_code = meal_id // 10_000_000_000_000
+    try:
+        return next(c for c in CampusLocation if c.code == campus_code)
+    except StopIteration:
+        raise ValueError(
+            f"Invalid meal ID {meal_id}: unknown campus code {campus_code}"
+        ) from None
+
+
+# 14-digit int: campus(1) + source_idx(1) + YYYYMMDD(8) + counter(02) + meal(02)
+MealId = Annotated[int, Field(ge=10_000_000_000_000, le=99_999_999_999_999)]

--- a/server/src/main.py
+++ b/server/src/main.py
@@ -3,6 +3,7 @@ from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
 
 from fastapi import FastAPI, HTTPException, Request
+from fastapi.exceptions import RequestValidationError
 from fastapi.responses import Response
 from loguru import logger
 from slowapi.errors import RateLimitExceeded
@@ -14,8 +15,11 @@ from src.api.health import router as health_router
 from src.api.mensa import router as mensa_router
 from src.api.more import router as more_router
 from src.api.news import router as news_router
+from src.core.enums import Language
+from src.core.locale import MEAL_NOT_FOUND
 from src.core.logging import setup_logging
 from src.core.rate_limits import limiter
+from src.core.routes import Route
 
 
 @asynccontextmanager
@@ -45,6 +49,24 @@ async def rate_limit_exceeded_handler(
     return Response(
         status_code=429, content="Too many requests.", media_type="text/plain"
     )
+
+
+@app.exception_handler(RequestValidationError)
+async def validation_error_handler(
+    request: Request, exc: RequestValidationError
+) -> Response:
+    if request.url.path.endswith(Route.MENSA_MEAL_DETAIL):
+        lang_str = request.query_params.get("language", "en")
+        try:
+            lang = Language(lang_str)
+        except ValueError:
+            lang = Language.EN
+        return Response(
+            status_code=404,
+            content=MEAL_NOT_FOUND[lang],
+            media_type="text/plain",
+        )
+    return Response(status_code=422, content="Invalid request.", media_type="text/plain")
 
 
 @app.exception_handler(HTTPException)

--- a/server/src/models/mensa.py
+++ b/server/src/models/mensa.py
@@ -1,6 +1,11 @@
 from __future__ import annotations
 
-from pydantic import BaseModel, ConfigDict, Field
+from typing import Annotated
+
+from pydantic import BaseModel, ConfigDict, Field, PlainSerializer
+
+# int stored internally; serialized as string in JSON for iOS SwiftyJSON compatibility.
+IntAsStr = Annotated[int, PlainSerializer(str, return_type=str, when_used="json")]
 
 
 class MensaColor(BaseModel):
@@ -37,7 +42,7 @@ class MensaMeal(BaseModel):
 
     model_config = ConfigDict(populate_by_name=True)
 
-    id: int
+    id: IntAsStr
     meal_name: str = Field(alias="mealName")
     counter_name: str = Field(alias="counterName")
     opening_hours: str = Field(alias="openingHours")
@@ -67,7 +72,7 @@ class MensaMealDetail(BaseModel):
 
     model_config = ConfigDict(populate_by_name=True)
 
-    id: int
+    id: IntAsStr
     meal_name: str = Field(alias="mealName")
     description: str
     color: MensaColor = Field(default_factory=MensaColor)

--- a/server/src/services/date_service.py
+++ b/server/src/services/date_service.py
@@ -38,9 +38,8 @@ _WEEKDAY_NAMES: dict[Language, list[str]] = {
 def mensa_target_date(now: datetime) -> date:
     """Return the date whose menu to display for a given datetime.
 
-    - Mon–Fri before 14:00: today
-    - Mon–Thu at/after 14:00: tomorrow
-    - Fri at/after 14:00, Sat, Sun: next Monday
+    - Mon–Fri: today
+    - Sat, Sun: next Monday
     """
     current = now.date()
     weekday = current.weekday()  # 0 = Mon … 6 = Sun
@@ -48,10 +47,6 @@ def mensa_target_date(now: datetime) -> date:
     if weekday == 5:  # Saturday → Monday
         return current + timedelta(days=2)
     if weekday == 6:  # Sunday → Monday
-        return current + timedelta(days=1)
-    if now.hour >= 14:
-        if weekday == 4:  # Friday after 14:00 → Monday
-            return current + timedelta(days=3)
         return current + timedelta(days=1)
     return current
 

--- a/server/src/services/map_service.py
+++ b/server/src/services/map_service.py
@@ -7,13 +7,13 @@ from pathlib import Path
 from loguru import logger
 
 from src.core.constants import CAMPUS_CITY_NAMES
-from src.core.enums import MensaLocation
+from src.core.enums import CampusLocation
 from src.models.map import MapEntry, MapResponse
 
 
 def _campus_city(raw: str) -> str:
     try:
-        return CAMPUS_CITY_NAMES[MensaLocation(raw)]
+        return CAMPUS_CITY_NAMES[CampusLocation(raw)]
     except (KeyError, ValueError):
         return raw
 
@@ -52,7 +52,7 @@ class MapService:
                             website=str(item.get("website", "")),
                         )
                     )
-                except Exception:
-                    logger.warning("Skipping malformed map entry: {}", item)
+                except Exception as exc:
+                    logger.warning("Skipping malformed map entry {}: {}", item, exc)
         update_time = datetime.now(UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
         return MapResponse(map_info=entries, update_time=update_time)

--- a/server/src/services/mensa_scraper.py
+++ b/server/src/services/mensa_scraper.py
@@ -284,7 +284,7 @@ class MensaScraper(BaseScraper):
                     date_str,
                 )
                 day_date = date.today()
-                formatted_date = date_str
+                formatted_date = format_mensa_date(day_date, lang)
 
             meals: list[MensaMeal] = []
             counters = day_data.get("counters", [])

--- a/server/src/services/mensa_scraper.py
+++ b/server/src/services/mensa_scraper.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 import json
-from datetime import UTC, datetime
+from datetime import UTC, date, datetime
+
+from loguru import logger
 
 from src.core.config import settings
 from src.core.constants import (
@@ -11,6 +13,7 @@ from src.core.constants import (
     MENSA_MENU_URL,
 )
 from src.core.enums import Language, MensaLocation
+from src.core.meal_id import generate_meal_id
 from src.models.mensa import (
     MensaColor,
     MensaComponent,
@@ -86,7 +89,7 @@ class MensaScraper(BaseScraper):
         """Normalize a string field from the mensa API.
 
         Reverses UTF-8-as-Latin-1 double-encoding present in some API strings.
-        E.g. "\u00c3\u00a9" (two Latin-1 code points) re-decodes as UTF-8 to "e\u0301".
+        E.g. "Ã©" (two Latin-1 code points) re-decodes as UTF-8 to "é".
         Correctly stored German umlauts are preserved: their single Latin-1
         bytes (0xfc for u with umlaut, etc.) are not valid standalone UTF-8,
         so the except branch returns them unchanged.
@@ -121,8 +124,22 @@ class MensaScraper(BaseScraper):
         counter_desc: str,
         opening_hours: str,
         color: MensaColor,
-        meal_id: int,
-    ) -> MensaMeal:
+        location: MensaLocation,
+        day: date,
+        counter_idx: int,
+        meal_idx: int,
+    ) -> MensaMeal | None:
+        try:
+            meal_id = generate_meal_id(location, day, counter_idx, meal_idx)
+        except ValueError:
+            logger.warning(
+                "mensa:{} — skipping meal at counter={} meal={} (ID out of range)",
+                location,
+                counter_idx,
+                meal_idx,
+            )
+            return None
+
         raw_notices = meal_data.get("notices", [])
         all_notices: set[str] = set(
             raw_notices if isinstance(raw_notices, list) else []
@@ -221,14 +238,12 @@ class MensaScraper(BaseScraper):
             )
             for n_id, info in self._notices.items()
         ]
-        campus_ids = set(MENSA_CAMPUS_LOCATIONS)
         locations = [
             MensaFilterLocation(
-                location_id=loc.location_id,
-                name=CAMPUS_CITY_NAMES.get(MensaLocation(loc.location_id), loc.name),
+                location_id=campus.value,
+                name=CAMPUS_CITY_NAMES[campus],
             )
-            for loc in self._filter_locations
-            if loc.location_id in campus_ids
+            for campus in MENSA_CAMPUS_LOCATIONS
         ]
         return MensaFilters(locations=locations, notices=notices)
 
@@ -236,7 +251,6 @@ class MensaScraper(BaseScraper):
         self,
         location: MensaLocation,
         lang: Language = Language.DE,
-        starting_meal_id: int = 0,
     ) -> MensaMenu:
         await self._fetch_base_data(lang)
         self._meal_details = {}
@@ -248,7 +262,6 @@ class MensaScraper(BaseScraper):
         raw = await self.fetch(url)
         data: dict[str, object] = json.loads(raw)
 
-        meal_id = starting_meal_id
         days: list[MensaDay] = []
 
         raw_days = data.get("days", [])
@@ -261,8 +274,16 @@ class MensaScraper(BaseScraper):
             date_str = str(day_data.get("date", ""))
             try:
                 day_dt = datetime.fromisoformat(date_str).astimezone(UTC)
-                formatted_date = format_mensa_date(day_dt.date(), lang)
+                day_date = day_dt.date()
+                formatted_date = format_mensa_date(day_date, lang)
             except ValueError:
+                logger.warning(
+                    "mensa:{}:{} — unparseable date {!r}, falling back to today",
+                    location,
+                    lang,
+                    date_str,
+                )
+                day_date = date.today()
                 formatted_date = date_str
 
             meals: list[MensaMeal] = []
@@ -270,7 +291,7 @@ class MensaScraper(BaseScraper):
             if not isinstance(counters, list):
                 counters = []
 
-            for counter in counters:
+            for counter_idx, counter in enumerate(counters):
                 if not isinstance(counter, dict):
                     continue
                 counter_name = self._clean(str(counter.get("displayName", "")))
@@ -289,20 +310,22 @@ class MensaScraper(BaseScraper):
                 raw_meals = counter.get("meals", [])
                 if not isinstance(raw_meals, list):
                     raw_meals = []
-                for meal_data in raw_meals:
+                for meal_idx, meal_data in enumerate(raw_meals):
                     if not isinstance(meal_data, dict):
                         continue
-                    meals.append(
-                        self._parse_meal(
-                            meal_data,
-                            counter_name,
-                            counter_desc,
-                            opening_hours,
-                            color,
-                            meal_id,
-                        )
+                    meal = self._parse_meal(
+                        meal_data,
+                        counter_name,
+                        counter_desc,
+                        opening_hours,
+                        color,
+                        location,
+                        day_date,
+                        counter_idx,
+                        meal_idx,
                     )
-                    meal_id += 1
+                    if meal is not None:
+                        meals.append(meal)
 
             days.append(MensaDay(date=formatted_date, meals=meals))
 

--- a/server/src/services/scheduler.py
+++ b/server/src/services/scheduler.py
@@ -13,9 +13,13 @@ from apscheduler.triggers.cron import CronTrigger
 from loguru import logger
 
 from src.core.config import settings
-from src.core.constants import MENSA_LANGUAGES, MENSA_LOCATIONS, NEWSFEED_LANGUAGES
-from src.core.enums import Language, MensaLocation
+from src.core.constants import (
+    MENSA_CAMPUS_LOCATIONS,
+    SUPPORTED_LANGUAGES,
+)
+from src.core.enums import Language
 from src.core.logging import setup_logging
+from src.core.meal_id import CAMPUS_SOURCES
 from src.models.mensa import MensaDay, MensaMealDetail, MensaMenu
 from src.services.helpful_numbers_service import HelpfulNumbersService
 from src.services.map_service import MapService
@@ -80,7 +84,7 @@ def _merge_mensa_menus(primary: MensaMenu, secondary: MensaMenu) -> MensaMenu:
 
 async def _run_news_job(cache: CacheClient) -> None:
     async with NewsAndEventsScraper() as scraper:
-        for lang in NEWSFEED_LANGUAGES:
+        for lang in SUPPORTED_LANGUAGES:
             feed = await scraper.fetch_news(lang)
             logger.info("fetched news:{} → {} items → cached", lang, len(feed.items))
             logger.trace(
@@ -106,86 +110,50 @@ async def _run_news_job(cache: CacheClient) -> None:
     await cache.set_async(cache_keys.scheduler_last_run("news"), _now_iso())
 
 
-async def _cache_mensa_location(
-    cache: CacheClient,
-    scraper: MensaScraper,
-    location: MensaLocation,
-    lang: Language,
-    sb_menu: MensaMenu | None,
-    sb_meal_details: dict[int, MensaMealDetail],
-) -> tuple[MensaMenu | None, dict[int, MensaMealDetail]]:
-    # Offset mensagarten IDs so they don't collide with sb IDs
-    # when both are merged into the sb cache key.
-    offset = (
-        sum(len(d.meals) for d in sb_menu.days)
-        if location == MensaLocation.MENSAGARTEN and sb_menu is not None
-        else 0
-    )
-    menu = await scraper.fetch_menu(location, lang, starting_meal_id=offset)
-    meal_details = scraper.get_meal_details()
-    logger.info(
-        "fetched mensa:{}:{} → {} days → cached", location, lang, len(menu.days)
-    )
-    logger.trace(
-        "parsed mensa:{}:{} — first day: {}",
-        location,
-        lang,
-        menu.days[0].date if menu.days else None,
-    )
-    await cache.set_async(
-        cache_keys.mensa_menu(location, lang),
-        menu.model_dump(by_alias=True, mode="json"),
-    )
-    logger.trace(
-        "extracted mensa:{}:{} meal details → {} meals → cached",
-        location,
-        lang,
-        len(meal_details),
-    )
-    await cache.set_async(
-        cache_keys.mensa_meal(location, lang),
-        {
-            str(k): v.model_dump(by_alias=True, mode="json")
-            for k, v in meal_details.items()
-        },
-    )
-
-    if location == MensaLocation.SB:
-        return menu, dict(meal_details)
-
-    if location == MensaLocation.MENSAGARTEN and sb_menu is not None:
-        merged = _merge_mensa_menus(sb_menu, menu)
-        merged_details = {**sb_meal_details, **meal_details}
-        logger.info(
-            "merged mensa:mensagarten:{} into mensa:sb:{} → {} days → cached",
-            lang,
-            lang,
-            len(merged.days),
-        )
-        await cache.set_async(
-            cache_keys.mensa_menu("sb", lang),
-            merged.model_dump(by_alias=True, mode="json"),
-        )
-        await cache.set_async(
-            cache_keys.mensa_meal("sb", lang),
-            {
-                str(k): v.model_dump(by_alias=True, mode="json")
-                for k, v in merged_details.items()
-            },
-        )
-
-    return sb_menu, sb_meal_details
-
-
 async def _cache_mensa_for_lang(
     cache: CacheClient, scraper: MensaScraper, lang: Language
 ) -> None:
-    sb_menu: MensaMenu | None = None
-    sb_meal_details: dict[int, MensaMealDetail] = {}
-    for location in MENSA_LOCATIONS:
-        sb_menu, sb_meal_details = await _cache_mensa_location(
-            cache, scraper, location, lang, sb_menu, sb_meal_details
-        )
+    for campus, sources in CAMPUS_SOURCES.items():
+        campus_menu: MensaMenu | None = None
+        campus_meal_details: dict[int, MensaMealDetail] = {}
+        last_exc: Exception | None = None
+        for source in sources:
+            try:
+                menu = await scraper.fetch_menu(source, lang)
+            except Exception as exc:
+                logger.warning(
+                    "mensa:{}:{} — fetch failed, skipping: {}", source, lang, exc
+                )
+                last_exc = exc
+                continue
+            meal_details = scraper.get_meal_details()
+            logger.info("fetched mensa:{}:{} → {} days", source, lang, len(menu.days))
+            if campus_menu is None:
+                campus_menu = menu
+                campus_meal_details = dict(meal_details)
+            else:
+                campus_menu = _merge_mensa_menus(campus_menu, menu)
+                campus_meal_details.update(meal_details)
+                logger.info(
+                    "merged mensa:{} into campus:{} → {} days",
+                    source,
+                    campus,
+                    len(campus_menu.days),
+                )
+        if campus_menu is None and last_exc is not None:
+            raise last_exc
+        if campus_menu is not None:
+            await cache.set_async(
+                cache_keys.mensa_menu(campus, lang),
+                campus_menu.model_dump(by_alias=True, mode="json"),
+            )
+            await cache.set_async(
+                cache_keys.mensa_meal(campus, lang),
+                {
+                    str(k): v.model_dump(by_alias=True, mode="json")
+                    for k, v in campus_meal_details.items()
+                },
+            )
     filters = scraper.build_filters()
     logger.trace(
         "built mensa:filters:{} → {} locations, {} notices → cached",
@@ -200,14 +168,14 @@ async def _cache_mensa_for_lang(
 
 async def _cache_mensa_info(cache: CacheClient) -> None:
     info_service = MensaInfoService()
-    for location in MENSA_LOCATIONS:
-        for lang in MENSA_LANGUAGES:
-            info = info_service.load(location, lang)
+    for campus in MENSA_CAMPUS_LOCATIONS:
+        for lang in SUPPORTED_LANGUAGES:
+            info = info_service.load(campus, lang)
             _outcome = "cached" if info is not None else "not found, skipped"
-            logger.trace("read mensa:info:{}:{} → {}", location, lang, _outcome)
+            logger.trace("read mensa:info:{}:{} → {}", campus, lang, _outcome)
             if info is not None:
                 await cache.set_async(
-                    cache_keys.mensa_info(location, lang),
+                    cache_keys.mensa_info(campus, lang),
                     info.model_dump(by_alias=True, mode="json"),
                 )
 
@@ -215,15 +183,15 @@ async def _cache_mensa_info(cache: CacheClient) -> None:
 async def _run_mensa_job(cache: CacheClient) -> None:
     try:
         async with MensaScraper() as scraper:
-            for lang in MENSA_LANGUAGES:
+            for lang in SUPPORTED_LANGUAGES:
                 await _cache_mensa_for_lang(cache, scraper, lang)
         await _cache_mensa_info(cache)
     except Exception:
         last_run = await cache.get_async(cache_keys.scheduler_last_run("mensa"))
         if _is_mensa_stale(last_run):
-            for location in MENSA_LOCATIONS:
-                for lang in MENSA_LANGUAGES:
-                    await cache.set_async(cache_keys.mensa_menu(location, lang), None)
+            for campus in MENSA_CAMPUS_LOCATIONS:
+                for lang in SUPPORTED_LANGUAGES:
+                    await cache.set_async(cache_keys.mensa_menu(campus, lang), None)
         raise
     await cache.set_async(cache_keys.scheduler_last_run("mensa"), _now_iso())
 
@@ -231,7 +199,7 @@ async def _run_mensa_job(cache: CacheClient) -> None:
 async def _run_helpful_numbers_job(cache: CacheClient) -> None:
     service = HelpfulNumbersService()
     more_service = MoreLinksService()
-    for lang in NEWSFEED_LANGUAGES:
+    for lang in SUPPORTED_LANGUAGES:
         data = service.load(lang)
         logger.info(
             "loaded helpful_numbers:{} → {} entries → cached",

--- a/server/src/services/scheduler.py
+++ b/server/src/services/scheduler.py
@@ -192,6 +192,7 @@ async def _run_mensa_job(cache: CacheClient) -> None:
             for campus in MENSA_CAMPUS_LOCATIONS:
                 for lang in SUPPORTED_LANGUAGES:
                     await cache.set_async(cache_keys.mensa_menu(campus, lang), None)
+                    await cache.set_async(cache_keys.mensa_meal(campus, lang), None)
         raise
     await cache.set_async(cache_keys.scheduler_last_run("mensa"), _now_iso())
 

--- a/server/src/storage/cache_keys.py
+++ b/server/src/storage/cache_keys.py
@@ -1,27 +1,29 @@
 from __future__ import annotations
 
+from src.core.enums import CampusLocation, Language
 
-def news(lang: str) -> str:
+
+def news(lang: Language) -> str:
     return f"news:{lang}"
 
 
-def events(lang: str) -> str:
+def events(lang: Language) -> str:
     return f"events:{lang}"
 
 
-def mensa_menu(location: str, lang: str) -> str:
+def mensa_menu(location: CampusLocation, lang: Language) -> str:
     return f"mensa:{location}:{lang}"
 
 
-def mensa_meal(location: str, lang: str) -> str:
-    return f"mensa:meal:{location}:{lang}"
+def mensa_meal(location: CampusLocation, lang: Language) -> str:
+    return f"mensa_meal_v1:{location}:{lang}"
 
 
-def mensa_filters(lang: str) -> str:
+def mensa_filters(lang: Language) -> str:
     return f"mensa:filters:{lang}"
 
 
-def mensa_info(location: str, lang: str) -> str:
+def mensa_info(location: CampusLocation, lang: Language) -> str:
     return f"mensa:info:{location}:{lang}"
 
 

--- a/server/tests/api/test_routes.py
+++ b/server/tests/api/test_routes.py
@@ -81,8 +81,8 @@ _MENSA_MENU = {
 }
 
 _MEAL_MAP = {
-    "0": {
-        "id": 0,
+    "10202601010000": {
+        "id": 10202601010000,
         "mealName": "Spaghetti",
         "description": "Pasta counter",
         "color": {"r": 0, "g": 0, "b": 0},
@@ -269,7 +269,7 @@ class TestMensaMealDetail:
             "src.api.mensa.cache.get_async",
             _cache_returning(_MEAL_MAP),
         ):
-            r = await client.get("/mensa/mealDetail?meal=0&location=sb&language=de")
+            r = await client.get("/mensa/mealDetail?meal=10202601010000&language=de")
         assert r.status_code == 200
         data = r.json()
         assert data["mealName"] == "Spaghetti"
@@ -281,12 +281,12 @@ class TestMensaMealDetail:
             "src.api.mensa.cache.get_async",
             _cache_returning(_MEAL_MAP),
         ):
-            r = await client.get("/mensa/mealDetail?meal=999&location=sb&language=de")
+            r = await client.get("/mensa/mealDetail?meal=10202601019999&language=de")
         assert r.status_code == 404
 
     async def test_missing_cache_returns_503(self, client: AsyncClient) -> None:
         with patch("src.api.mensa.cache.get_async", _cache_returning(None)):
-            r = await client.get("/mensa/mealDetail?meal=0&location=sb&language=de")
+            r = await client.get("/mensa/mealDetail?meal=10202601010000&language=de")
         assert r.status_code == 503
 
 

--- a/server/tests/api/test_routes.py
+++ b/server/tests/api/test_routes.py
@@ -82,7 +82,7 @@ _MENSA_MENU = {
 
 _MEAL_MAP = {
     "10202601010000": {
-        "id": 10202601010000,
+        "id": "10202601010000",
         "mealName": "Spaghetti",
         "description": "Pasta counter",
         "color": {"r": 0, "g": 0, "b": 0},

--- a/server/tests/services/test_date_service.py
+++ b/server/tests/services/test_date_service.py
@@ -12,11 +12,11 @@ from src.services.date_service import format_mensa_date, mensa_target_date
     "now, expected",
     [
         (datetime(2020, 1, 6, 9, 0), date(2020, 1, 6)),  # Monday morning → today
-        (datetime(2020, 1, 6, 14, 0), date(2020, 1, 7)),  # Monday 14:00 → tomorrow
+        (datetime(2020, 1, 6, 14, 0), date(2020, 1, 6)),  # Monday 14:00 → today
         (datetime(2020, 1, 9, 9, 0), date(2020, 1, 9)),  # Thursday morning → today
-        (datetime(2020, 1, 9, 14, 0), date(2020, 1, 10)),  # Thursday 14:00 → Friday
+        (datetime(2020, 1, 9, 14, 0), date(2020, 1, 9)),  # Thursday 14:00 → today
         (datetime(2020, 1, 10, 9, 0), date(2020, 1, 10)),  # Friday morning → today
-        (datetime(2020, 1, 10, 14, 0), date(2020, 1, 13)),  # Friday 14:00 → Monday
+        (datetime(2020, 1, 10, 14, 0), date(2020, 1, 10)),  # Friday 14:00 → today
         (datetime(2020, 1, 11, 12, 0), date(2020, 1, 13)),  # Saturday → Monday
         (datetime(2020, 1, 12, 12, 0), date(2020, 1, 13)),  # Sunday → Monday
     ],

--- a/server/tests/services/test_mensa_scraper.py
+++ b/server/tests/services/test_mensa_scraper.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from unittest.mock import AsyncMock, patch
 
+from src.core.enums import MensaLocation
 from src.services.base_scraper import BaseScraper
 from src.services.mensa_scraper import MensaScraper
 
@@ -40,7 +41,7 @@ async def _fetch_menu(menu_json: str = _MENU_SB) -> object:
         ),
     ):
         scraper = MensaScraper()
-        return await scraper.fetch_menu("sb", "de")
+        return await scraper.fetch_menu(MensaLocation.MENSB, "de")
 
 
 async def test_fetch_menu_first_day_date() -> None:
@@ -198,10 +199,11 @@ async def test_main_screen_components_capped_at_five() -> None:
         ),
     ):
         scraper = MensaScraper()
-        menu = await scraper.fetch_menu("sb", "de")
+        menu = await scraper.fetch_menu(MensaLocation.MENSB, "de")
 
+    meal_id = menu.days[0].meals[0].id
     assert len(menu.days[0].meals[0].components) == 5
-    assert len(scraper.get_meal_details()[0].meal_components) == 8
+    assert len(scraper.get_meal_details()[meal_id].meal_components) == 8
 
 
 async def test_component_with_tab_filtered_from_main_not_detail() -> None:
@@ -222,14 +224,15 @@ async def test_component_with_tab_filtered_from_main_not_detail() -> None:
         ),
     ):
         scraper = MensaScraper()
-        menu = await scraper.fetch_menu("sb", "de")
+        menu = await scraper.fetch_menu(MensaLocation.MENSB, "de")
 
     main_components = menu.days[0].meals[0].components
     assert "Tomatensalat" in main_components
     assert not any("\t" in c for c in main_components)
 
+    meal_id = menu.days[0].meals[0].id
     detail_names = [
-        mc.component_name for mc in scraper.get_meal_details()[0].meal_components
+        mc.component_name for mc in scraper.get_meal_details()[meal_id].meal_components
     ]
     assert any("\t" in n for n in detail_names)
 
@@ -252,14 +255,15 @@ async def test_component_with_newline_filtered_from_main_not_detail() -> None:
         ),
     ):
         scraper = MensaScraper()
-        menu = await scraper.fetch_menu("sb", "de")
+        menu = await scraper.fetch_menu(MensaLocation.MENSB, "de")
 
     main_components = menu.days[0].meals[0].components
     assert "Kartoffeln" in main_components
     assert not any("\n" in c for c in main_components)
 
+    meal_id = menu.days[0].meals[0].id
     detail_names = [
-        mc.component_name for mc in scraper.get_meal_details()[0].meal_components
+        mc.component_name for mc in scraper.get_meal_details()[meal_id].meal_components
     ]
     assert any("\n" in n for n in detail_names)
 
@@ -275,7 +279,7 @@ async def test_fetch_menu_missing_price_tiers_falls_back_to_tier_id() -> None:
         ),
     ):
         scraper = MensaScraper()
-        menu = await scraper.fetch_menu("sb", "de")
+        menu = await scraper.fetch_menu(MensaLocation.MENSB, "de")
     prices = menu.days[0].meals[0].prices
     assert prices is not None
     tags = {p.price_tag for p in prices}

--- a/server/tests/services/test_scheduler.py
+++ b/server/tests/services/test_scheduler.py
@@ -7,7 +7,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from apscheduler.schedulers.asyncio import AsyncIOScheduler
 
-from src.core.constants import MENSA_LANGUAGES, MENSA_LOCATIONS
+from src.core.constants import MENSA_CAMPUS_LOCATIONS, SUPPORTED_LANGUAGES
 from src.models.mensa import MensaMenu
 from src.services.scheduler import (
     _initialize,
@@ -21,7 +21,9 @@ from src.services.scheduler import (
 from src.storage.cache import CacheClient
 
 _ALL_MENSA_KEYS = [
-    f"mensa:{loc}:{lang}" for loc in MENSA_LOCATIONS for lang in MENSA_LANGUAGES
+    f"mensa:{loc}:{lang}"
+    for loc in MENSA_CAMPUS_LOCATIONS
+    for lang in SUPPORTED_LANGUAGES
 ]
 
 
@@ -40,7 +42,7 @@ def _mock_news_scraper(feed: MagicMock) -> AsyncMock:
     return scraper
 
 
-def _mock_mensa_scraper(feed: MagicMock | None = None) -> AsyncMock:  # noqa: ARG001
+def _mock_mensa_scraper() -> AsyncMock:
     scraper = AsyncMock()
     scraper.__aenter__ = AsyncMock(return_value=scraper)
     scraper.__aexit__ = AsyncMock(return_value=False)
@@ -144,7 +146,7 @@ async def test_news_job_failure_preserves_existing_cache(tmp_path: Path) -> None
 
 async def test_mensa_job_writes_all_location_language_keys(tmp_path: Path) -> None:
     cache = CacheClient(cache_dir=str(tmp_path))
-    scraper = _mock_mensa_scraper(_mock_feed({"days": []}))
+    scraper = _mock_mensa_scraper()
     with (
         patch("src.services.scheduler.MensaScraper", return_value=scraper),
         patch("src.services.scheduler.MensaInfoService") as MockInfo,
@@ -358,7 +360,7 @@ async def test_run_all_jobs_once_continues_after_single_job_failure(
     failing_news.__aexit__ = AsyncMock(return_value=False)
     failing_news.fetch_news.side_effect = Exception("news down")
 
-    working_mensa = _mock_mensa_scraper(_mock_feed({"days": []}))
+    working_mensa = _mock_mensa_scraper()
 
     with (
         patch("src.services.scheduler.NewsAndEventsScraper", return_value=failing_news),
@@ -388,7 +390,7 @@ async def test_initialize_writes_ready_status_after_successful_startup(
     cache = CacheClient(cache_dir=str(tmp_path))
     scheduler = AsyncIOScheduler()
     scraper = _mock_news_scraper(_mock_feed())
-    working_mensa = _mock_mensa_scraper(_mock_feed())
+    working_mensa = _mock_mensa_scraper()
     with (
         patch("src.services.scheduler.NewsAndEventsScraper", return_value=scraper),
         patch("src.services.scheduler.MensaScraper", return_value=working_mensa),

--- a/server/tests/storage/test_cache_keys.py
+++ b/server/tests/storage/test_cache_keys.py
@@ -16,7 +16,7 @@ def test_mensa_menu_key_format() -> None:
 
 
 def test_mensa_meal_key_format() -> None:
-    assert cache_keys.mensa_meal("hom", "fr") == "mensa:meal:hom:fr"
+    assert cache_keys.mensa_meal("hom", "fr") == "mensa_meal_v1:hom:fr"
 
 
 def test_mensa_filters_key_format() -> None:


### PR DESCRIPTION

The old server used sequential per-campus meal IDs starting at 0. A HOM user tapping meal id=0 would receive SB's meal 0 because the detail route defaulted to SB when no location was sent.  

- Replaced sequential IDs with stable encoding IDs encoding (not big fan of this, but the iOS app expected an id) 
- Cafe b4r1sta is now showing in SB Mensa feed
- Scheduler merges Mensa sources by campus (not Mensa counters). fetching or parsing failures (mensagarten, b4r1sta, ..) is no longer discard the Mensa source's cached data
- Cleaned up type annotations, enum design, and lint


Next steps:
- Wire up mensa_target_date in get_mensa_menu in a follow-up PR