### PR TITLE
ViewModels: replace state-as-event with closures & more layers separate 

### DIFF
--- a/iOSApp/Uni Saar/Supportive/SingleButtonAlert.swift
+++ b/iOSApp/Uni Saar/Supportive/SingleButtonAlert.swift
@@ -12,8 +12,8 @@ import UIKit
 struct AlertAction {
     let buttonTitle: String = NSLocalizedString("AlertOkActionTitle", comment: "")
     let tryAgainButtonTitle: String = NSLocalizedString("tryAgain", comment: "")
-    let handler: (() -> Void)?
-    let tryAgainHandler: (() -> Void)?
+    let handler: (@MainActor () -> Void)?
+    let tryAgainHandler: (@MainActor () -> Void)?
 }
 
 struct SingleButtonAlert {

--- a/iOSApp/Uni Saar/Supportive/SingleButtonAlert.swift
+++ b/iOSApp/Uni Saar/Supportive/SingleButtonAlert.swift
@@ -12,7 +12,6 @@ import UIKit
 struct AlertAction {
     let buttonTitle: String = NSLocalizedString("AlertOkActionTitle", comment: "")
     let tryAgainButtonTitle: String = NSLocalizedString("tryAgain", comment: "")
-    let handler: (@MainActor () -> Void)?
     let tryAgainHandler: (@MainActor () -> Void)?
 }
 

--- a/iOSApp/Uni Saar/Supportive/UIViewController.swift
+++ b/iOSApp/Uni Saar/Supportive/UIViewController.swift
@@ -21,7 +21,7 @@ extension SingleButtonDialogPresenter where Self: UIViewController {
                                                 preferredStyle: .alert)
         alertController.addAction(UIAlertAction(title: alert.action.buttonTitle,
                                                 style: .default,
-                                                handler: { _ in alert.action.handler?() }))
+                                                handler: nil))
         if let tryAgainHandler = alert.action.tryAgainHandler {
             alertController.addAction(UIAlertAction(title: alert.action.tryAgainButtonTitle,
                                                     style: .default,

--- a/iOSApp/Uni Saar/ViewControllers/DirectoryViewControllers/DirectoryViewController.swift
+++ b/iOSApp/Uni Saar/ViewControllers/DirectoryViewControllers/DirectoryViewController.swift
@@ -32,7 +32,7 @@ class DirectoryViewController: UIViewController {
         setupSearchBar()
         setupTableView()
         observeKeyboardEvents()
-        directoryViewModel.onAlert = { [weak self] alert in self?.presentSingleButtonDialog(alert: alert) }
+        setupViewModel()
         refershLoad()
     }
 
@@ -43,6 +43,12 @@ class DirectoryViewController: UIViewController {
     private func updateUI() {
         if directoryViewModel.showLoadingIndicator { directoryTableView.showingLoadingView() } else { directoryTableView.hideLoadingView() }
         directoryTableView.reloadData()
+    }
+
+    private func setupViewModel() {
+        directoryViewModel.onAlert = { [weak self] alert in self?.presentSingleButtonDialog(alert: alert) }
+        directoryViewModel.onRetry = { [weak self] in self?.refershLoad() }
+        // bindings only — load fires last in viewDidLoad
     }
 
     func setupSearchBar() {

--- a/iOSApp/Uni Saar/ViewControllers/DirectoryViewControllers/HelpfulContactsViewController.swift
+++ b/iOSApp/Uni Saar/ViewControllers/DirectoryViewControllers/HelpfulContactsViewController.swift
@@ -23,8 +23,12 @@ class HelpfulContactsViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         setupTableView()
-        directoryViewModel.onAlert = { [weak self] alert in self?.presentSingleButtonDialog(alert: alert) }
+        setupViewModel()
         refershLoad()
+    }
+
+    private func setupViewModel() {
+        directoryViewModel.onAlert = { [weak self] alert in self?.presentSingleButtonDialog(alert: alert) }
     }
 
     override func updateProperties() {

--- a/iOSApp/Uni Saar/ViewControllers/DirectoryViewControllers/StaffDetailsViewController.swift
+++ b/iOSApp/Uni Saar/ViewControllers/DirectoryViewControllers/StaffDetailsViewController.swift
@@ -25,8 +25,12 @@ class StaffDetailsViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         navigateButton.isHidden = true
-        staff.onAlert = { [weak self] alert in self?.presentSingleButtonDialog(alert: alert) }
+        setupViewModel()
         setupInitialDataLoad()
+    }
+
+    private func setupViewModel() {
+        staff.onAlert = { [weak self] alert in self?.presentSingleButtonDialog(alert: alert) }
     }
 
     /// NATIVE iOS 26 API: The framework automatically tracks any @Observable referenced inside here.

--- a/iOSApp/Uni Saar/ViewControllers/MensaViewControllers/FilterMensaViewController.swift
+++ b/iOSApp/Uni Saar/ViewControllers/MensaViewControllers/FilterMensaViewController.swift
@@ -28,6 +28,7 @@ class FilterMensaViewController: UIViewController {
 
     lazy var filterMensaViewModel: FilterMensaViewModel = .init()
     weak var delegate: FilterMensaViewDelegate?
+    private var loadTask: Task<Void, Never>?
 
     private func filterForSectionIndex(_ index: Int) -> FilterMensaViewModel.Filter? {
         FilterMensaViewModel.Filter(rawValue: index)
@@ -36,8 +37,8 @@ class FilterMensaViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         setupTableView()
-        filterMensaViewModel.onAlert = { [weak self] alert in self?.presentSingleButtonDialog(alert: alert) }
-        Task { [weak self] in await self?.filterMensaViewModel.loadGetFilterList() }
+        setupViewModel()
+        load()
     }
 
     override func updateProperties() {
@@ -51,8 +52,15 @@ class FilterMensaViewController: UIViewController {
 
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
+        loadTask?.cancel()
         AppSessionManager.shared.foodAlarmTime = filterMensaViewModel.selectedAlramTime
         AppSessionManager.saveFoodAlarmStatus()
+    }
+
+    private func setupViewModel() {
+        filterMensaViewModel.onAlert = { [weak self] alert in self?.presentSingleButtonDialog(alert: alert) }
+        filterMensaViewModel.onRetry = { [weak self] in self?.load() }
+        // bindings only — load fires last in viewDidLoad
     }
 
     func setupTableView() {
@@ -66,7 +74,12 @@ class FilterMensaViewController: UIViewController {
 
     @objc private func refershLoad() {
         filterMensaViewModel.isFilterdCacheUpdated = false
-        Task { [weak self] in await self?.filterMensaViewModel.loadGetFilterList() }
+        load()
+    }
+
+    private func load() {
+        loadTask?.cancel()
+        loadTask = Task { [weak self] in await self?.filterMensaViewModel.loadGetFilterList() }
     }
 
     @IBAction func doneButtonAction(_ sender: Any) {

--- a/iOSApp/Uni Saar/ViewControllers/MensaViewControllers/MealDetailsViewController.swift
+++ b/iOSApp/Uni Saar/ViewControllers/MensaViewControllers/MealDetailsViewController.swift
@@ -25,8 +25,12 @@ class MealDetailsViewController: UIViewController {
         title = mealItemViewModel?.counterDisplayName
         colorView.setAsCircle(cornerRadius: colorView.frame.height / 2)
         colorView.backgroundColor = mealItemViewModel.map { AppStyle.mensaCounterColor($0.colorModel) }
-        meal.onAlert = { [weak self] alert in self?.presentSingleButtonDialog(alert: alert) }
+        setupViewModel()
         setupInitialState()
+    }
+
+    private func setupViewModel() {
+        meal.onAlert = { [weak self] alert in self?.presentSingleButtonDialog(alert: alert) }
     }
 
     /// NATIVE iOS 26 API: The framework automatically tracks any @Observable referenced inside here.

--- a/iOSApp/Uni Saar/ViewControllers/MensaViewControllers/MensaLocationsInfoViewController.swift
+++ b/iOSApp/Uni Saar/ViewControllers/MensaViewControllers/MensaLocationsInfoViewController.swift
@@ -34,7 +34,7 @@ class MensaLocationsInfoViewController: UIViewController {
                 }
                 title = mensaInfo.locationName
             } catch {
-                let okAlert = SingleButtonAlert(message: error.localizedDescription, action: AlertAction(handler: nil, tryAgainHandler: { [weak self] in
+                let okAlert = SingleButtonAlert(message: error.localizedDescription, action: AlertAction(tryAgainHandler: { [weak self] in
                     self?.loadAgain()
                 }))
                 presentSingleButtonDialog(alert: okAlert)

--- a/iOSApp/Uni Saar/ViewControllers/MensaViewControllers/MensaViewController.swift
+++ b/iOSApp/Uni Saar/ViewControllers/MensaViewControllers/MensaViewController.swift
@@ -20,12 +20,18 @@ class MensaViewController: UIViewController {
     }
 
     lazy var mensaMenuViewModel: MensaMenuViewModel = .init()
+    private var loadTask: Task<Void, Never>?
 
     override func viewDidLoad() {
         super.viewDidLoad()
         setupCollectionView()
-        mensaMenuViewModel.onAlert = { [weak self] alert in self?.presentSingleButtonDialog(alert: alert) }
+        setupViewModel()
         load()
+    }
+
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        loadTask?.cancel()
     }
 
     override func updateProperties() {
@@ -53,7 +59,14 @@ class MensaViewController: UIViewController {
     }
 
     @objc func load() {
-        Task { [weak self] in await self?.mensaMenuViewModel.loadGetMensaMenu() }
+        loadTask?.cancel()
+        loadTask = Task { [weak self] in await self?.mensaMenuViewModel.loadGetMensaMenu() }
+    }
+
+    private func setupViewModel() {
+        mensaMenuViewModel.onAlert = { [weak self] alert in self?.presentSingleButtonDialog(alert: alert) }
+        mensaMenuViewModel.onRetry = { [weak self] in self?.load() }
+        // bindings only — load fires last in viewDidLoad
     }
 
     func setupCollectionView() {

--- a/iOSApp/Uni Saar/ViewControllers/MensaViewControllers/MensaViewController.swift
+++ b/iOSApp/Uni Saar/ViewControllers/MensaViewControllers/MensaViewController.swift
@@ -79,7 +79,7 @@ class MensaViewController: UIViewController {
     }
 
     func isMenuUpdated() {
-        mensaMenuViewModel.isMenuUpdated()
+        if mensaMenuViewModel.isMenuOutdated() { load() }
     }
 
     func initialSelection() {

--- a/iOSApp/Uni Saar/ViewControllers/MoreViewControllers/MoreLinksViewController.swift
+++ b/iOSApp/Uni Saar/ViewControllers/MoreViewControllers/MoreLinksViewController.swift
@@ -15,7 +15,7 @@ class MoreLinksViewController: UITableViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         setRefreshControl()
-        moreLinksViewModel.onAlert = { [weak self] alert in self?.presentSingleButtonDialog(alert: alert) }
+        setupViewModel()
         Task { [weak self] in await self?.moreLinksViewModel.loadGetMoreLinks() }
     }
 
@@ -27,6 +27,12 @@ class MoreLinksViewController: UITableViewController {
         if moreLinksViewModel.showLoadingIndicator { tableView.showingLoadingView() } else { tableView.hideLoadingView() }
         tableView.reloadData()
         requestReview()
+    }
+
+    private func setupViewModel() {
+        moreLinksViewModel.onAlert = { [weak self] alert in self?.presentSingleButtonDialog(alert: alert) }
+        moreLinksViewModel.onRetry = { [weak self] in self?.refershLoad() }
+        // bindings only — load fires last in viewDidLoad
     }
 
     func setRefreshControl() {

--- a/iOSApp/Uni Saar/ViewControllers/NewsFeedViewControllers/EventCalanderViewController.swift
+++ b/iOSApp/Uni Saar/ViewControllers/NewsFeedViewControllers/EventCalanderViewController.swift
@@ -33,7 +33,7 @@ class EventCalanderViewController: UIViewController {
         super.viewDidLoad()
         setUpCalander()
         setupTableView()
-        eventViewModel.onAlert = { [weak self] alert in self?.presentSingleButtonDialog(alert: alert) }
+        setupViewModel()
         load()
     }
 
@@ -49,6 +49,12 @@ class EventCalanderViewController: UIViewController {
     private func updateUI() {
         if eventViewModel.showLoadingIndicator { tableView.showingLoadingView() } else { tableView.hideLoadingView() }
         tableView.reloadData()
+    }
+
+    private func setupViewModel() {
+        eventViewModel.onAlert = { [weak self] alert in self?.presentSingleButtonDialog(alert: alert) }
+        eventViewModel.onRetry = { [weak self] in self?.load() }
+        // bindings only — load fires last in viewDidLoad
     }
 
     func setUpCalander() {

--- a/iOSApp/Uni Saar/ViewControllers/NewsFeedViewControllers/EventCalanderViewController.swift
+++ b/iOSApp/Uni Saar/ViewControllers/NewsFeedViewControllers/EventCalanderViewController.swift
@@ -21,6 +21,7 @@ class EventCalanderViewController: UIViewController {
     }
 
     lazy var eventViewModel: EventViewModel = .init()
+    private var loadTask: Task<Void, Never>?
 
     fileprivate let formatter: DateFormatter = {
         let formatter = DateFormatter()
@@ -36,24 +37,24 @@ class EventCalanderViewController: UIViewController {
         load()
     }
 
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        loadTask?.cancel()
+    }
+
     override func updateProperties() {
         updateUI()
     }
 
     private func updateUI() {
         if eventViewModel.showLoadingIndicator { tableView.showingLoadingView() } else { tableView.hideLoadingView() }
-        calendar.reloadData()
         tableView.reloadData()
-        if !eventViewModel.eventCells.isEmpty, eventViewModel.selectedDateEvents.isEmpty {
-            Task { @MainActor [weak self] in
-                self?.eventViewModel.getDayEvents(day: self?.calendar.today)
-            }
-        }
     }
 
     func setUpCalander() {
         calendar.delegate = self
         calendar.dataSource = self
+        calendar.allowsMultipleSelection = false
         view.backgroundColor = UIColor.flatGray
         calendar.appearance.titleDefaultColor = UIColor.labelCustomColor
         calendar.appearance.headerTitleColor = UIColor.labelCustomColor
@@ -61,8 +62,13 @@ class EventCalanderViewController: UIViewController {
     }
 
     @objc func load() {
+        loadTask?.cancel()
         let currentCalendarDate = getCurrentDate()
-        Task { [weak self] in await self?.eventViewModel.loadGetEvents(month: currentCalendarDate.month, year: currentCalendarDate.year) }
+        loadTask = Task { [weak self] in
+            await self?.eventViewModel.loadGetEvents(month: currentCalendarDate.month, year: currentCalendarDate.year)
+            guard !Task.isCancelled else { return }
+            self?.calendar.reloadData()
+        }
     }
 
     func getCurrentDate() -> (month: String, year: String) {
@@ -102,15 +108,13 @@ class EventCalanderViewController: UIViewController {
 extension EventCalanderViewController: @preconcurrency FSCalendarDelegate, @preconcurrency FSCalendarDataSource {
     func calendarCurrentPageDidChange(_ calendar: FSCalendar) {
         load()
-        eventViewModel.selectedDateEvents = []
     }
 
     func calendar(_ calendar: FSCalendar, didSelect date: Date, at monthPosition: FSCalendarMonthPosition) {
         if monthPosition == .previous || monthPosition == .next {
             calendar.setCurrentPage(date, animated: true)
-        } else {
-            eventViewModel.getDayEvents(day: date)
         }
+        eventViewModel.getDayEvents(day: date)
     }
 
     func calendar(_ calendar: FSCalendar, numberOfEventsFor date: Date) -> Int {

--- a/iOSApp/Uni Saar/ViewControllers/NewsFeedViewControllers/FilterNewsFeedViewController.swift
+++ b/iOSApp/Uni Saar/ViewControllers/NewsFeedViewControllers/FilterNewsFeedViewController.swift
@@ -30,8 +30,7 @@ class FilterNewsFeedViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         setupTableView()
-        filterNewsViewModel.onAlert = { [weak self] alert in self?.presentSingleButtonDialog(alert: alert) }
-        filterNewsViewModel.onFilterListUpdated = { [weak self] in self?.filterTableView.reloadData() }
+        setupViewModel()
         Task { [weak self] in await self?.filterNewsViewModel.loadGetFilterList() }
     }
 
@@ -41,6 +40,13 @@ class FilterNewsFeedViewController: UIViewController {
 
     private func updateUI() {
         if filterNewsViewModel.showLoadingIndicator { filterTableView.showingLoadingView() } else { filterTableView.hideLoadingView() }
+    }
+
+    private func setupViewModel() {
+        filterNewsViewModel.onAlert = { [weak self] alert in self?.presentSingleButtonDialog(alert: alert) }
+        filterNewsViewModel.onRetry = { [weak self] in self?.refershLoad() }
+        filterNewsViewModel.onFilterListUpdated = { [weak self] in self?.filterTableView.reloadData() }
+        // bindings only — load fires last in viewDidLoad
     }
 
     func setupTableView() {

--- a/iOSApp/Uni Saar/ViewControllers/NewsFeedViewControllers/FilterNewsFeedViewController.swift
+++ b/iOSApp/Uni Saar/ViewControllers/NewsFeedViewControllers/FilterNewsFeedViewController.swift
@@ -31,6 +31,7 @@ class FilterNewsFeedViewController: UIViewController {
         super.viewDidLoad()
         setupTableView()
         filterNewsViewModel.onAlert = { [weak self] alert in self?.presentSingleButtonDialog(alert: alert) }
+        filterNewsViewModel.onFilterListUpdated = { [weak self] in self?.filterTableView.reloadData() }
         Task { [weak self] in await self?.filterNewsViewModel.loadGetFilterList() }
     }
 
@@ -40,13 +41,6 @@ class FilterNewsFeedViewController: UIViewController {
 
     private func updateUI() {
         if filterNewsViewModel.showLoadingIndicator { filterTableView.showingLoadingView() } else { filterTableView.hideLoadingView() }
-        if filterNewsViewModel.didUpdatefilterList {
-            Task { @MainActor [weak self] in
-                guard let self else { return }
-                filterNewsViewModel.didUpdatefilterList = false
-                filterTableView.reloadData()
-            }
-        }
     }
 
     func setupTableView() {

--- a/iOSApp/Uni Saar/ViewControllers/NewsFeedViewControllers/NewsFeedViewController.swift
+++ b/iOSApp/Uni Saar/ViewControllers/NewsFeedViewControllers/NewsFeedViewController.swift
@@ -19,12 +19,23 @@ class NewsFeedViewController: UIViewController {
     }
 
     lazy var newsViewModel: NewsFeedViewModel = .init()
+    private let paginationSpinner: UIActivityIndicatorView = {
+        let spinner = UIActivityIndicatorView(style: .medium)
+        spinner.startAnimating()
+        spinner.frame = CGRect(x: 0, y: 0, width: 0, height: 50)
+        return spinner
+    }()
 
     override func viewDidLoad() {
         super.viewDidLoad()
         setupTableView()
         newsViewModel.onAlert = { [weak self] alert in self?.presentSingleButtonDialog(alert: alert) }
-        Task { [weak self] in await self?.newsViewModel.loadGetNews(filterCatgroies: []) }
+        newsViewModel.onInitialLoad = { [weak self] in
+            guard let self else { return }
+            newsTable.reloadData()
+            initialSelection()
+        }
+        Task { [weak self] in await self?.newsViewModel.loadFirstPage(filterCatgroies: []) }
     }
 
     override func updateProperties() {
@@ -33,22 +44,12 @@ class NewsFeedViewController: UIViewController {
 
     private func updateUI() {
         if newsViewModel.showLoadingIndicator { newsTable.showingLoadingView() } else { newsTable.hideLoadingView() }
-        if newsViewModel.isFreshLoad {
-            Task { @MainActor [weak self] in
-                guard let self else { return }
-                newsViewModel.isFreshLoad = false
-                initialSelection()
-            }
-        }
+        newsTable.tableFooterView = newsViewModel.isPaginating ? paginationSpinner : nil
         newsTable.reloadData()
     }
 
     @objc private func refershLoad() {
-        load(isFirstTime: true, filterCatgroies: [])
-    }
-
-    @objc func load(isFirstTime: Bool = true, filterCatgroies: [Int]) {
-        Task { [weak self] in await self?.newsViewModel.loadGetNews(isFirstTime, filterCatgroies: filterCatgroies) }
+        Task { [weak self] in await self?.newsViewModel.loadFirstPage(filterCatgroies: []) }
     }
 
     func setupTableView() {
@@ -136,7 +137,7 @@ extension NewsFeedViewController {
         let currentOffset = scrollView.contentOffset.y
         let maximumOffset = scrollView.contentSize.height - scrollView.frame.size.height
         if maximumOffset - currentOffset <= 25.0 {
-            load(isFirstTime: false, filterCatgroies: [])
+            Task { [weak self] in await self?.newsViewModel.loadNextPage(filterCatgroies: []) }
         }
     }
 }
@@ -145,7 +146,7 @@ extension NewsFeedViewController: SingleButtonDialogPresenter {}
 
 extension NewsFeedViewController: FilterNewsFeedViewDelegate {
     func didSelectFilterAll() {
-        load(filterCatgroies: [])
+        Task { [weak self] in await self?.newsViewModel.loadFirstPage(filterCatgroies: []) }
     }
 
     func scrollUp() {
@@ -154,6 +155,6 @@ extension NewsFeedViewController: FilterNewsFeedViewDelegate {
 
     func didSelectCustomFiltering(newsCatgroies: [Int]) {
         scrollUp()
-        load(filterCatgroies: newsCatgroies)
+        Task { [weak self] in await self?.newsViewModel.loadFirstPage(filterCatgroies: newsCatgroies) }
     }
 }

--- a/iOSApp/Uni Saar/ViewControllers/NewsFeedViewControllers/NewsFeedViewController.swift
+++ b/iOSApp/Uni Saar/ViewControllers/NewsFeedViewControllers/NewsFeedViewController.swift
@@ -29,12 +29,7 @@ class NewsFeedViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         setupTableView()
-        newsViewModel.onAlert = { [weak self] alert in self?.presentSingleButtonDialog(alert: alert) }
-        newsViewModel.onInitialLoad = { [weak self] in
-            guard let self else { return }
-            newsTable.reloadData()
-            initialSelection()
-        }
+        setupViewModel()
         Task { [weak self] in await self?.newsViewModel.loadFirstPage(filterCatgroies: []) }
     }
 
@@ -50,6 +45,15 @@ class NewsFeedViewController: UIViewController {
 
     @objc private func refershLoad() {
         Task { [weak self] in await self?.newsViewModel.loadFirstPage(filterCatgroies: []) }
+    }
+
+    private func setupViewModel() {
+        newsViewModel.onAlert = { [weak self] alert in self?.presentSingleButtonDialog(alert: alert) }
+        newsViewModel.onInitialLoad = { [weak self] in
+            guard let self else { return }
+            newsTable.reloadData()
+            initialSelection()
+        }
     }
 
     func setupTableView() {

--- a/iOSApp/Uni Saar/ViewModels/DirectoryViewModel.swift
+++ b/iOSApp/Uni Saar/ViewModels/DirectoryViewModel.swift
@@ -82,14 +82,8 @@ class DirectoryViewModel: ParentViewModel {
             if AppSessionManager.shared.helpfulNumbersLastChanged == "never" {
                 helpfulNumbersCells = [.error(message: error.localizedDescription)]
             }
-            showError(error: error, tryAgainHandler: { [weak self] in
-                self?.reloadGetApi()
-            })
+            showError(error: error)
         }
-    }
-
-    func reloadGetApi() {
-        Task { await self.loadGetHelpHelpfulNumbers() }
     }
 
     func loadGetMockSearchResults() {}

--- a/iOSApp/Uni Saar/ViewModels/EventViewModel.swift
+++ b/iOSApp/Uni Saar/ViewModels/EventViewModel.swift
@@ -70,9 +70,9 @@ class EventViewModel: ParentViewModel {
     }
 
     static let eventDateFormatter: DateFormatter = {
-        let f = DateFormatter()
-        f.dateFormat = "yyyy'-'MM'-'dd'"
-        return f
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "yyyy'-'MM'-'dd'"
+        return dateFormatter
     }()
 
     func convertDate(strDate: String) -> Date? {

--- a/iOSApp/Uni Saar/ViewModels/EventViewModel.swift
+++ b/iOSApp/Uni Saar/ViewModels/EventViewModel.swift
@@ -13,6 +13,7 @@ import Observation
 class EventViewModel: ParentViewModel {
     var eventCells: [TableViewCellType<NewsFeedCellViewModel>] = []
     var selectedDateEvents: [TableViewCellType<NewsFeedCellViewModel>] = []
+    @ObservationIgnored private(set) var currentSelectedDate: Date?
 
     override init(dataClient: any AppDataClient = DataClient()) {
         super.init(dataClient: dataClient)
@@ -28,6 +29,9 @@ class EventViewModel: ParentViewModel {
                 return
             }
             eventCells = events.newsList.compactMap { .normal(cellViewModel: $0 as NewsFeedCellViewModel) }
+            getDayEvents(day: currentSelectedDate ?? Calendar.current.startOfDay(for: Date()))
+        } catch is CancellationError {
+            showLoadingIndicator = false
         } catch {
             showLoadingIndicator = false
             eventCells = [.error(message: error.localizedDescription)]
@@ -36,6 +40,7 @@ class EventViewModel: ParentViewModel {
     }
 
     func getDayEvents(day: Date?) {
+        currentSelectedDate = day
         selectedDateEvents = eventCells.filter { item -> Bool in
             switch item {
             case let .normal(event):

--- a/iOSApp/Uni Saar/ViewModels/EventViewModel.swift
+++ b/iOSApp/Uni Saar/ViewModels/EventViewModel.swift
@@ -69,9 +69,13 @@ class EventViewModel: ParentViewModel {
         return events.count
     }
 
+    static let eventDateFormatter: DateFormatter = {
+        let f = DateFormatter()
+        f.dateFormat = "yyyy'-'MM'-'dd'"
+        return f
+    }()
+
     func convertDate(strDate: String) -> Date? {
-        let dateFormatter = DateFormatter()
-        dateFormatter.dateFormat = "yyyy'-'MM'-'dd'"
-        return dateFormatter.date(from: strDate)
+        EventViewModel.eventDateFormatter.date(from: strDate)
     }
 }

--- a/iOSApp/Uni Saar/ViewModels/FilterMensaViewModel.swift
+++ b/iOSApp/Uni Saar/ViewModels/FilterMensaViewModel.swift
@@ -13,8 +13,7 @@ import UserNotifications
 
 @Observable
 class FilterMensaViewModel: ParentViewModel {
-    var didUpdatefilterList: Bool = false
-    var didUpdateFoodAlarmStatus: Bool = false
+    @ObservationIgnored var onFilterListUpdated: (@MainActor () -> Void)?
     var selectedAlramTime: Date? {
         didSet { AppSessionManager.shared.foodAlarmTime = selectedAlramTime }
     }
@@ -48,7 +47,7 @@ class FilterMensaViewModel: ParentViewModel {
                 AppSessionManager.shared.isMensaFiltersCacheFetched = true
             }
             showLoadingIndicator = false
-            didUpdatefilterList = true
+            onFilterListUpdated?()
             return
         }
         do {
@@ -60,19 +59,12 @@ class FilterMensaViewModel: ParentViewModel {
             dataClient.saveInCoreDataWith(model: viewModelList)
             isFilterdCacheUpdated = true
             Cache.shared.fetchMensaFilterFromStorage()
-            didUpdatefilterList = true
+            onFilterListUpdated?()
             AppSessionManager.shared.isMensaFiltersCacheFetched = true
         } catch {
             showLoadingIndicator = false
-            didUpdatefilterList = false
-            showError(error: error, tryAgainHandler: { [weak self] in
-                self?.reloadGetApi()
-            })
+            showError(error: error)
         }
-    }
-
-    func reloadGetApi() {
-        Task { await self.loadGetFilterList() }
     }
 
     func filterList(for fliter: Filter) -> [FilterElement] {
@@ -167,7 +159,6 @@ extension FilterMensaViewModel {
     }
 
     func updateSwitchButton(switchOn: Bool = false) {
-        didUpdateFoodAlarmStatus = switchOn
         isFoodAlarmEnabled = switchOn
         if switchOn {
             scheduleNotification()

--- a/iOSApp/Uni Saar/ViewModels/FilterNewsViewModel.swift
+++ b/iOSApp/Uni Saar/ViewModels/FilterNewsViewModel.swift
@@ -12,7 +12,7 @@ import Observation
 
 @Observable
 class FilterNewsViewModel: ParentViewModel {
-    var didUpdatefilterList: Bool = false
+    @ObservationIgnored var onFilterListUpdated: (@MainActor () -> Void)?
     var isFilterdCacheUpdated: Bool = false
     @ObservationIgnored var fetchedResultsController: NSFetchedResultsController<NewsCategoriesCache> = {
         let fetchRequest = NSFetchRequest<NewsCategoriesCache>(entityName: String(describing: NewsCategoriesCache.self))
@@ -34,8 +34,8 @@ class FilterNewsViewModel: ParentViewModel {
         showLoadingIndicator = true
         fetchNewsFilterFromStorage()
         if isFilterdCacheUpdated {
-            didUpdatefilterList = true
             showLoadingIndicator = false
+            onFilterListUpdated?()
             return
         }
         do {
@@ -47,10 +47,9 @@ class FilterNewsViewModel: ParentViewModel {
             dataClient.saveInCoreDataWith(model: viewModelList)
             fetchNewsFilterFromStorage()
             isFilterdCacheUpdated = true
-            didUpdatefilterList = true
+            onFilterListUpdated?()
         } catch {
             showLoadingIndicator = false
-            didUpdatefilterList = false
             showError(error: error, tryAgainHandler: { [weak self] in
                 self?.reloadGetApi()
             })

--- a/iOSApp/Uni Saar/ViewModels/FilterNewsViewModel.swift
+++ b/iOSApp/Uni Saar/ViewModels/FilterNewsViewModel.swift
@@ -50,14 +50,8 @@ class FilterNewsViewModel: ParentViewModel {
             onFilterListUpdated?()
         } catch {
             showLoadingIndicator = false
-            showError(error: error, tryAgainHandler: { [weak self] in
-                self?.reloadGetApi()
-            })
+            showError(error: error)
         }
-    }
-
-    func reloadGetApi() {
-        Task { await self.loadGetFilterList() }
     }
 
     func getOldSelectedCategories(newViewModel: FilterCategoriesCellViewModel) -> [FilterIntElement] {

--- a/iOSApp/Uni Saar/ViewModels/MensaViewModel.swift
+++ b/iOSApp/Uni Saar/ViewModels/MensaViewModel.swift
@@ -44,19 +44,13 @@ class MensaMenuViewModel: ParentViewModel {
         }
     }
 
-    func realodGetApi() {
-        Task { [weak self] in await self?.loadGetMensaMenu() }
-    }
-
     func loadGetMockMenu() {
         daysMenus = MensaMenuModel.menuDemoData.daysMenus.compactMap { .normal(cellViewModel: MensaDayMenuViewModel(mensaDayModel: $0)) }
     }
 
-    func isMenuUpdated() {
-        guard case let .normal(viewModel) = daysMenus.first else { return }
-        if viewModel.dateValue != getDateFormater(date: Date()) {
-            Task { [weak self] in await self?.loadGetMensaMenu() }
-        }
+    func isMenuOutdated() -> Bool {
+        guard case let .normal(viewModel) = daysMenus.first else { return false }
+        return viewModel.dateValue != getDateFormater(date: Date())
     }
 
     func getDateFormater(date: Date) -> String {

--- a/iOSApp/Uni Saar/ViewModels/MensaViewModel.swift
+++ b/iOSApp/Uni Saar/ViewModels/MensaViewModel.swift
@@ -40,14 +40,12 @@ class MensaMenuViewModel: ParentViewModel {
             if daysMenus.isEmpty {
                 daysMenus = [.error(message: error.localizedDescription)]
             }
-            showError(error: error, tryAgainHandler: { [weak self] in
-                self?.realodGetApi()
-            })
+            showError(error: error)
         }
     }
 
     func realodGetApi() {
-        Task { await self.loadGetMensaMenu() }
+        Task { [weak self] in await self?.loadGetMensaMenu() }
     }
 
     func loadGetMockMenu() {
@@ -57,7 +55,7 @@ class MensaMenuViewModel: ParentViewModel {
     func isMenuUpdated() {
         guard case let .normal(viewModel) = daysMenus.first else { return }
         if viewModel.dateValue != getDateFormater(date: Date()) {
-            Task { await self.loadGetMensaMenu() }
+            Task { [weak self] in await self?.loadGetMensaMenu() }
         }
     }
 

--- a/iOSApp/Uni Saar/ViewModels/MoreLinksViewModel.swift
+++ b/iOSApp/Uni Saar/ViewModels/MoreLinksViewModel.swift
@@ -49,14 +49,8 @@ class MoreLinksViewModel: ParentViewModel {
             if AppSessionManager.shared.morelinksLastChanged == "never" {
                 linksCells = [.error(message: error.localizedDescription)]
             }
-            showError(error: error, tryAgainHandler: { [weak self] in
-                self?.reloadGetApi()
-            })
+            showError(error: error)
         }
-    }
-
-    func reloadGetApi() {
-        Task { await self.loadGetMoreLinks() }
     }
 
     func fetchMoreLinksFromStorage() {

--- a/iOSApp/Uni Saar/ViewModels/NewsFeedViewModel.swift
+++ b/iOSApp/Uni Saar/ViewModels/NewsFeedViewModel.swift
@@ -13,8 +13,9 @@ import Observation
 @Observable
 class NewsFeedViewModel: ParentViewModel {
     var newsCells: [TableViewCellType<NewsFeedCellViewModel>] = []
-    var isFreshLoad: Bool = false
+    var isPaginating: Bool = false
     var apiPageNumber = 0
+    @ObservationIgnored var onInitialLoad: (@MainActor () -> Void)?
     let numberOfItemPerPage = 10
     var isFilterdCacheUpdated = false
     @ObservationIgnored lazy var fetchedResultsController: NSFetchedResultsController<NewsCategoriesCache> = {
@@ -28,34 +29,54 @@ class NewsFeedViewModel: ParentViewModel {
         super.init(dataClient: dataClient)
     }
 
-    func loadGetNews(_ isFirstTime: Bool = true, filterCatgroies: [Int]) async {
+    func loadFirstPage(filterCatgroies: [Int]) async {
+        guard !showLoadingIndicator else { return }
         showLoadingIndicator = true
+        apiPageNumber = 0
         var filterCatgroies = filterCatgroies
         if filterCatgroies.count == 0 {
             fetchNewsFilterFromStorage()
             filterCatgroies = fetchedResultsController.fetchedObjects?.filter { !$0.isSelected }.compactMap { Int($0.categoryID) } ?? []
         }
         do {
-            let news = try await dataClient.getNews(pageNumber: isFirstTime ? 0 : apiPageNumber, numberOfItems: numberOfItemPerPage, filter: filterCatgroies)
+            let news = try await dataClient.getNews(pageNumber: 0, numberOfItems: numberOfItemPerPage, filter: filterCatgroies)
             showLoadingIndicator = false
-            if isFirstTime {
-                guard news.newsItemCount > 0 else {
-                    newsCells = [.empty]
-                    return
-                }
-                isFilterdCacheUpdated = true
-                if AppSessionManager.shared.newsFiltersLastChanged != news.categoriesLastChanged {
-                    AppSessionManager.shared.newsFiltersLastChanged = news.categoriesLastChanged
-                    isFilterdCacheUpdated = false
-                }
-                newsCells = news.newsList.compactMap { .normal(cellViewModel: $0 as NewsFeedCellViewModel) }
-                isFreshLoad = true
-            } else {
-                newsCells.append(contentsOf: news.newsList.compactMap { .normal(cellViewModel: $0 as NewsFeedCellViewModel) })
+            guard news.newsItemCount > 0 else {
+                newsCells = [.empty]
+                return
             }
+            isFilterdCacheUpdated = true
+            if AppSessionManager.shared.newsFiltersLastChanged != news.categoriesLastChanged {
+                AppSessionManager.shared.newsFiltersLastChanged = news.categoriesLastChanged
+                isFilterdCacheUpdated = false
+            }
+            newsCells = news.newsList.compactMap { .normal(cellViewModel: $0 as NewsFeedCellViewModel) }
             apiPageNumber += 1
+            onInitialLoad?()
         } catch {
             showLoadingIndicator = false
+            if newsCells.isEmpty {
+                newsCells = [.error(message: error.localizedDescription)]
+            }
+            showError(error: error)
+        }
+    }
+
+    func loadNextPage(filterCatgroies: [Int]) async {
+        guard !isPaginating else { return }
+        isPaginating = true
+        var filterCatgroies = filterCatgroies
+        if filterCatgroies.isEmpty {
+            fetchNewsFilterFromStorage()
+            filterCatgroies = fetchedResultsController.fetchedObjects?.filter { !$0.isSelected }.compactMap { Int($0.categoryID) } ?? []
+        }
+        do {
+            let news = try await dataClient.getNews(pageNumber: apiPageNumber, numberOfItems: numberOfItemPerPage, filter: filterCatgroies)
+            isPaginating = false
+            newsCells.append(contentsOf: news.newsList.compactMap { .normal(cellViewModel: $0 as NewsFeedCellViewModel) })
+            apiPageNumber += 1
+        } catch {
+            isPaginating = false
             if newsCells.isEmpty {
                 newsCells = [.error(message: error.localizedDescription)]
             }

--- a/iOSApp/Uni Saar/ViewModels/ParentViewModel.swift
+++ b/iOSApp/Uni Saar/ViewModels/ParentViewModel.swift
@@ -14,14 +14,19 @@ import Observation
 class ParentViewModel {
     @ObservationIgnored var dataClient: any AppDataClient
     @ObservationIgnored var onAlert: (@MainActor (SingleButtonAlert) -> Void)?
+    @ObservationIgnored var onRetry: (@MainActor () -> Void)?
     var showLoadingIndicator: Bool = false
 
     init(dataClient: any AppDataClient = DataClient()) {
         self.dataClient = dataClient
     }
 
-    func showError(error: Error?, tryAgainHandler: (() -> Void)? = nil) {
-        onAlert?(SingleButtonAlert(message: error?.localizedDescription, action: AlertAction(handler: nil, tryAgainHandler: tryAgainHandler)))
+    func reloadGetApi() {
+        onRetry?()
+    }
+
+    func showError(error: Error?) {
+        onAlert?(SingleButtonAlert(message: error?.localizedDescription, action: AlertAction(handler: nil, tryAgainHandler: onRetry)))
     }
 
     func showError(error: LLError?) {

--- a/iOSApp/Uni Saar/ViewModels/ParentViewModel.swift
+++ b/iOSApp/Uni Saar/ViewModels/ParentViewModel.swift
@@ -26,10 +26,10 @@ class ParentViewModel {
     }
 
     func showError(error: Error?) {
-        onAlert?(SingleButtonAlert(message: error?.localizedDescription, action: AlertAction(handler: nil, tryAgainHandler: onRetry)))
+        onAlert?(SingleButtonAlert(message: error?.localizedDescription, action: AlertAction(tryAgainHandler: onRetry)))
     }
 
     func showError(error: LLError?) {
-        onAlert?(SingleButtonAlert(message: error?.message, action: AlertAction(handler: nil, tryAgainHandler: nil)))
+        onAlert?(SingleButtonAlert(message: error?.message, action: AlertAction(tryAgainHandler: nil)))
     }
 }

--- a/iOSApp/UniSaarTests/AlertControllerTest.swift
+++ b/iOSApp/UniSaarTests/AlertControllerTest.swift
@@ -12,17 +12,15 @@ import XCTest
 @MainActor
 final class AlertControllerTest: XCTestCase {
     func testAlert() {
-        var handlerCalled = false
+        var retried = false
 
         let alert = SingleButtonAlert(
-            message: "",
-            action: AlertAction(handler: {
-                handlerCalled = true
-            }, tryAgainHandler: nil)
+            message: "test error",
+            action: AlertAction(tryAgainHandler: { retried = true })
         )
 
-        alert.action.handler?()
+        alert.action.tryAgainHandler?()
 
-        XCTAssertTrue(handlerCalled, "Alert action handler should be called")
+        XCTAssertTrue(retried, "Try again handler should be called")
     }
 }

--- a/iOSApp/UniSaarTests/AlertControllerTest.swift
+++ b/iOSApp/UniSaarTests/AlertControllerTest.swift
@@ -9,7 +9,8 @@
 @testable import Uni_Saar
 import XCTest
 
-class AlertControllerTest: XCTestCase {
+@MainActor
+final class AlertControllerTest: XCTestCase {
     func testAlert() {
         var handlerCalled = false
 

--- a/iOSApp/UniSaarTests/EventViewModelTests.swift
+++ b/iOSApp/UniSaarTests/EventViewModelTests.swift
@@ -11,6 +11,22 @@ import XCTest
 
 @MainActor
 final class EventViewModelTests: XCTestCase {
+    func testSelectedDateEventsEmptyWhenNotCurrentMonth() async {
+        let dataClient = MockAppDataClient()
+        dataClient.getEventsResult = .success(NewsFeedModel.newsDemoData)
+        let viewModel = EventViewModel(dataClient: dataClient)
+        await viewModel.loadGetEvents(month: "12", year: "2019")
+        XCTAssertTrue(viewModel.selectedDateEvents.isEmpty)
+    }
+
+    func testSelectedDateEventsEmptyOnError() async {
+        let dataClient = MockAppDataClient()
+        dataClient.getEventsResult = .failure(MyError.customError)
+        let viewModel = EventViewModel(dataClient: dataClient)
+        await viewModel.loadGetEvents(month: "12", year: "2019")
+        XCTAssertTrue(viewModel.selectedDateEvents.isEmpty)
+    }
+
     func testNormalEventCells() async {
         let dataClient = MockAppDataClient()
         dataClient.getEventsResult = .success(NewsFeedModel.newsDemoData)

--- a/iOSApp/UniSaarTests/FilterMensaViewModelTests.swift
+++ b/iOSApp/UniSaarTests/FilterMensaViewModelTests.swift
@@ -23,20 +23,24 @@ final class FilterMensaViewModelTests: XCTestCase {
         super.tearDown()
     }
 
-    func testDidUpdateFilterListOnSuccess() async {
+    func testOnFilterListUpdatedFiredOnSuccess() async {
+        var fired = false
         let dataClient = MockAppDataClient()
         dataClient.getMensaFilterResult = .success(MensaFilterModel(json: [:]))
         let viewModel = FilterMensaViewModel(dataClient: dataClient)
+        viewModel.onFilterListUpdated = { fired = true }
         await viewModel.loadGetFilterList()
-        XCTAssertTrue(viewModel.didUpdatefilterList)
+        XCTAssertTrue(fired)
     }
 
-    func testDidUpdateFilterListFalseOnError() async {
+    func testOnFilterListUpdatedNotFiredOnError() async {
+        var fired = false
         let dataClient = MockAppDataClient()
         dataClient.getMensaFilterResult = .failure(MyError.customError)
         let viewModel = FilterMensaViewModel(dataClient: dataClient)
+        viewModel.onFilterListUpdated = { fired = true }
         await viewModel.loadGetFilterList()
-        XCTAssertFalse(viewModel.didUpdatefilterList)
+        XCTAssertFalse(fired)
     }
 
     func testOnAlertFiredOnError() async {

--- a/iOSApp/UniSaarTests/FilterNewsViewModelTests.swift
+++ b/iOSApp/UniSaarTests/FilterNewsViewModelTests.swift
@@ -11,23 +11,27 @@ import XCTest
 
 @MainActor
 final class FilterNewsViewModelTests: XCTestCase {
-    func testDidUpdateFilterListOnSuccess() async {
+    func testOnFilterListUpdatedFiredOnSuccess() async {
+        var fired = false
         let dataClient = MockAppDataClient()
         dataClient.getNewsCategoriesResult = .success([
             NewsCategories(json: ["id": 1, "name": "News"]),
             NewsCategories(json: ["id": 2, "name": "Events"])
         ])
         let viewModel = FilterNewsViewModel(dataClient: dataClient)
+        viewModel.onFilterListUpdated = { fired = true }
         await viewModel.loadGetFilterList()
-        XCTAssertTrue(viewModel.didUpdatefilterList)
+        XCTAssertTrue(fired)
     }
 
-    func testDidUpdateFilterListFalseOnError() async {
+    func testOnFilterListUpdatedNotFiredOnError() async {
+        var fired = false
         let dataClient = MockAppDataClient()
         dataClient.getNewsCategoriesResult = .failure(MyError.customError)
         let viewModel = FilterNewsViewModel(dataClient: dataClient)
+        viewModel.onFilterListUpdated = { fired = true }
         await viewModel.loadGetFilterList()
-        XCTAssertFalse(viewModel.didUpdatefilterList)
+        XCTAssertFalse(fired)
     }
 
     func testOnAlertFiredOnError() async {

--- a/iOSApp/UniSaarTests/NewsViewModelTests.swift
+++ b/iOSApp/UniSaarTests/NewsViewModelTests.swift
@@ -20,7 +20,7 @@ final class NewsViewModelTests: XCTestCase {
         let dataClient = MockAppDataClient()
         dataClient.getNewsResult = .success(NewsFeedModel.newsDemoData)
         let viewModel = NewsFeedViewModel(dataClient: dataClient)
-        await viewModel.loadGetNews(filterCatgroies: [])
+        await viewModel.loadFirstPage(filterCatgroies: [])
         guard case .normal = viewModel.newsCells.first else { XCTFail("Expected normal cell"); return }
     }
 
@@ -28,7 +28,7 @@ final class NewsViewModelTests: XCTestCase {
         let dataClient = MockAppDataClient()
         dataClient.getNewsResult = .success(NewsFeedModel(json: [:]))
         let viewModel = NewsFeedViewModel(dataClient: dataClient)
-        await viewModel.loadGetNews(filterCatgroies: [])
+        await viewModel.loadFirstPage(filterCatgroies: [])
         guard case .empty = viewModel.newsCells.first else { XCTFail("Expected empty cell"); return }
     }
 
@@ -36,17 +36,28 @@ final class NewsViewModelTests: XCTestCase {
         let dataClient = MockAppDataClient()
         dataClient.getNewsResult = .failure(MyError.customError)
         let viewModel = NewsFeedViewModel(dataClient: dataClient)
-        await viewModel.loadGetNews(filterCatgroies: [])
+        await viewModel.loadFirstPage(filterCatgroies: [])
         guard case .error = viewModel.newsCells.first else { XCTFail("Expected error cell"); return }
     }
 
-    func testIsFreshLoadSetAfterLoad() async {
-        let testSuccessfulJSON = NewsFeedModel.newsDemoData
+    func testOnInitialLoadFiredAfterFirstPage() async {
+        var fired = false
         let dataClient = MockAppDataClient()
-        dataClient.getNewsResult = .success(testSuccessfulJSON)
+        dataClient.getNewsResult = .success(NewsFeedModel.newsDemoData)
         let viewModel = NewsFeedViewModel(dataClient: dataClient)
-        await viewModel.loadGetNews(filterCatgroies: [])
-        XCTAssertTrue(viewModel.isFreshLoad)
+        viewModel.onInitialLoad = { fired = true }
+        await viewModel.loadFirstPage(filterCatgroies: [])
+        XCTAssertTrue(fired)
+    }
+
+    func testOnInitialLoadNotFiredOnNextPage() async {
+        var fired = false
+        let dataClient = MockAppDataClient()
+        dataClient.getNewsResult = .success(NewsFeedModel.newsDemoData)
+        let viewModel = NewsFeedViewModel(dataClient: dataClient)
+        viewModel.onInitialLoad = { fired = true }
+        await viewModel.loadNextPage(filterCatgroies: [])
+        XCTAssertFalse(fired)
     }
 
     func testNewsViewModelValues() async {
@@ -54,7 +65,7 @@ final class NewsViewModelTests: XCTestCase {
         let dataClient = MockAppDataClient()
         dataClient.getNewsResult = .success(news)
         let viewModel = NewsFeedViewModel(dataClient: dataClient)
-        await viewModel.loadGetNews(filterCatgroies: [])
+        await viewModel.loadFirstPage(filterCatgroies: [])
         guard case let .normal(cell) = viewModel.newsCells.first else { XCTFail("Expected normal cell"); return }
         XCTAssertEqual(news.newsList.first?.title, cell.titleText)
         XCTAssertEqual(news.newsList.first?.subTitle, cell.subTitleText)
@@ -69,12 +80,12 @@ final class NewsViewModelTests: XCTestCase {
         let viewModel = NewsFeedViewModel(dataClient: dataClient)
 
         // First page replaces cells
-        await viewModel.loadGetNews(filterCatgroies: [])
+        await viewModel.loadFirstPage(filterCatgroies: [])
         let firstPageCount = viewModel.newsCells.count
         XCTAssertGreaterThan(firstPageCount, 0, "First page should produce at least one cell")
 
-        // Second page (isFirstTime: false) should append, not replace
-        await viewModel.loadGetNews(false, filterCatgroies: [])
+        // Next page should append, not replace
+        await viewModel.loadNextPage(filterCatgroies: [])
         XCTAssertGreaterThan(viewModel.newsCells.count, firstPageCount,
                              "Second page load should append items to the existing cell list")
     }
@@ -85,10 +96,10 @@ final class NewsViewModelTests: XCTestCase {
         let viewModel = NewsFeedViewModel(dataClient: dataClient)
 
         XCTAssertEqual(viewModel.apiPageNumber, 0, "apiPageNumber should start at 0")
-        await viewModel.loadGetNews(filterCatgroies: [])
-        XCTAssertEqual(viewModel.apiPageNumber, 1, "apiPageNumber should increment to 1 after the first load")
-        await viewModel.loadGetNews(false, filterCatgroies: [])
-        XCTAssertEqual(viewModel.apiPageNumber, 2, "apiPageNumber should increment to 2 after the second load")
+        await viewModel.loadFirstPage(filterCatgroies: [])
+        XCTAssertEqual(viewModel.apiPageNumber, 1, "apiPageNumber should increment to 1 after the first page")
+        await viewModel.loadNextPage(filterCatgroies: [])
+        XCTAssertEqual(viewModel.apiPageNumber, 2, "apiPageNumber should increment to 2 after the next page")
     }
 
     func testFirstPageAlwaysReplacesCells() async {
@@ -96,11 +107,11 @@ final class NewsViewModelTests: XCTestCase {
         dataClient.getNewsResult = .success(NewsFeedModel.newsDemoData)
         let viewModel = NewsFeedViewModel(dataClient: dataClient)
 
-        await viewModel.loadGetNews(filterCatgroies: [])
+        await viewModel.loadFirstPage(filterCatgroies: [])
         let countAfterFirst = viewModel.newsCells.count
 
-        // Loading with isFirstTime: true again should reset, not accumulate
-        await viewModel.loadGetNews(true, filterCatgroies: [])
+        // Reloading the first page should replace cells, not accumulate
+        await viewModel.loadFirstPage(filterCatgroies: [])
         XCTAssertEqual(viewModel.newsCells.count, countAfterFirst,
                        "A first-page reload should replace cells rather than append to them")
     }

--- a/iOSApp/UniSaarTests/ObservableTest.swift
+++ b/iOSApp/UniSaarTests/ObservableTest.swift
@@ -36,7 +36,7 @@ final class ObservationTests: XCTestCase {
         dataClient.getNewsResult = .success(NewsFeedModel.newsDemoData)
         let viewModel = NewsFeedViewModel(dataClient: dataClient)
         XCTAssertTrue(viewModel.newsCells.isEmpty)
-        await viewModel.loadGetNews(filterCatgroies: [])
+        await viewModel.loadFirstPage(filterCatgroies: [])
         XCTAssertFalse(viewModel.newsCells.isEmpty)
         guard case let .normal(cell) = viewModel.newsCells.first else {
             XCTFail("Expected normal cell from mock")
@@ -53,7 +53,7 @@ final class ObservationTests: XCTestCase {
         let dataClient = MockAppDataClient()
         dataClient.getNewsResult = .success(NewsFeedModel.newsDemoData)
         let viewModel = NewsFeedViewModel(dataClient: dataClient)
-        let loadTask = Task { await viewModel.loadGetNews(filterCatgroies: []) }
+        let loadTask = Task { await viewModel.loadFirstPage(filterCatgroies: []) }
         // Yield to let the task run up to its first await (the actor-hop into MockAppDataClient)
         await Task.yield()
         XCTAssertTrue(viewModel.showLoadingIndicator, "showLoadingIndicator should be true while the load is in flight")

--- a/iOSApp/UniSaarTests/UpdatePropertiesLifecycleTests.swift
+++ b/iOSApp/UniSaarTests/UpdatePropertiesLifecycleTests.swift
@@ -49,7 +49,7 @@ final class UpdatePropertiesLifecycleTests: XCTestCase {
         let dataClient = MockAppDataClient()
         dataClient.getNewsResult = .success(NewsFeedModel.newsDemoData)
         viewController.newsViewModel = NewsFeedViewModel(dataClient: dataClient)
-        await viewController.newsViewModel.loadGetNews(filterCatgroies: [])
+        await viewController.newsViewModel.loadFirstPage(filterCatgroies: [])
 
         // Force the updateProperties() cycle → updateUI() → reloadData()
         viewController.setNeedsUpdateProperties()
@@ -74,7 +74,7 @@ final class UpdatePropertiesLifecycleTests: XCTestCase {
         let dataClient = MockAppDataClient()
         dataClient.getNewsResult = .success(NewsFeedModel(json: [:]))
         viewController.newsViewModel = NewsFeedViewModel(dataClient: dataClient)
-        await viewController.newsViewModel.loadGetNews(filterCatgroies: [])
+        await viewController.newsViewModel.loadFirstPage(filterCatgroies: [])
 
         viewController.setNeedsUpdateProperties()
         viewController.view.layoutIfNeeded()
@@ -100,7 +100,7 @@ final class UpdatePropertiesLifecycleTests: XCTestCase {
         let dataClient = MockAppDataClient()
         dataClient.getNewsResult = .failure(MyError.customError)
         viewController.newsViewModel = NewsFeedViewModel(dataClient: dataClient)
-        await viewController.newsViewModel.loadGetNews(filterCatgroies: [])
+        await viewController.newsViewModel.loadFirstPage(filterCatgroies: [])
 
         viewController.setNeedsUpdateProperties()
         viewController.view.layoutIfNeeded()

--- a/iOSApp/UniSaarTests/ViewExtensionTests.swift
+++ b/iOSApp/UniSaarTests/ViewExtensionTests.swift
@@ -100,7 +100,7 @@ final class LoadingIndicatorTests: XCTestCase {
         let dataClient = MockAppDataClient()
         dataClient.getNewsResult = .success(NewsFeedModel.newsDemoData)
         let viewModel = NewsFeedViewModel(dataClient: dataClient)
-        let task = Task { await viewModel.loadGetNews(filterCatgroies: []) }
+        let task = Task { await viewModel.loadFirstPage(filterCatgroies: []) }
         await Task.yield() // let Task start and execute synchronous preamble
         XCTAssertTrue(viewModel.showLoadingIndicator, "showLoadingIndicator should be true while loading")
         await task.value


### PR DESCRIPTION
Completes Issue #32 items 1–2. ViewModels are now passive: no internal Tasks, no untyped closures. SwiftUI views can bind to them directly without ViewModel changes.

- replaced bool states in vm with `@ObservationIgnored` closures
- remove vc-owned from vm : `onRetry` added to `ParentViewModel`; `reloadGetApi()` removed from all child ViewModels
- ViewModel closures typed `(@MainActor () -> Void)?` — consistent and SwiftUI-compatible
- `setupViewModel()` extracted in all touched VCs, to keep viewDidLoad : UI setup → bindings → load



known gaps:
loadTask + viewWillDisappear cancellation added to EventCalander, Mensa, FilterMensa. 
SwiftUI does not have a direct native equivalent to UIKit's viewWillDisappear(_:) 