### PR TITLE
refactor: unify AppError enum & strip out NSObject

### DIFF
--- a/iOSApp/Uni Saar/Models/MensaFilterList.swift
+++ b/iOSApp/Uni Saar/Models/MensaFilterList.swift
@@ -71,39 +71,25 @@ class FilterList {
     private var isDispalyAllergen: Bool = true
     private var allergenList: [ChecklistItem] = []
     init() {
-        let row0Item = ChecklistItem()
-        let row1Item = ChecklistItem()
-        let row2Item = ChecklistItem()
-        let row3Item = ChecklistItem()
-        let row4Item = ChecklistItem()
-        let row5Item = ChecklistItem()
-        let row6Item = ChecklistItem()
-        let row7Item = ChecklistItem()
-        let row8Item = ChecklistItem()
-        let row9Item = ChecklistItem()
-        let row10Item = ChecklistItem()
-        let row11Item = ChecklistItem()
-        let row12Item = ChecklistItem()
-        let row13Item = ChecklistItem()
-        let row20Item = ChecklistItem()
-        row0Item.text = "Mensa/Mensacafé Saarbrücken"
-        row1Item.text = "Mensa Homburg"
-        row2Item.text = "Mensagarden"
-        row3Item.text = "Cafeteria Hochschule für Musik Saar"
-        row4Item.text = "Artificial colouring"
-        row5Item.text = "Preservatives"
-        row6Item.text = "Antioxidants"
-        row7Item.text = "Flavour enhancer"
-        row8Item.text = "Sulphurised"
-        row9Item.text = "Blackened"
-        row10Item.text = "Pork"
-        row11Item.text = "Alcohol"
-        row12Item.text = "Nuts"
-        row13Item.text = "Without pork"
-        row20Item.text = "Toggle all"
-        mensaLocationsList = [row0Item, row1Item, row2Item, row3Item]
-        emptyList = [row20Item]
-        allergenList = [row4Item, row5Item, row6Item, row7Item, row8Item, row9Item, row10Item, row11Item, row12Item, row13Item]
+        mensaLocationsList = [
+            ChecklistItem(text: "Mensa/Mensacafé Saarbrücken"),
+            ChecklistItem(text: "Mensa Homburg"),
+            ChecklistItem(text: "Mensagarden"),
+            ChecklistItem(text: "Cafeteria Hochschule für Musik Saar")
+        ]
+        emptyList = [ChecklistItem(text: "Toggle all")]
+        allergenList = [
+            ChecklistItem(text: "Artificial colouring"),
+            ChecklistItem(text: "Preservatives"),
+            ChecklistItem(text: "Antioxidants"),
+            ChecklistItem(text: "Flavour enhancer"),
+            ChecklistItem(text: "Sulphurised"),
+            ChecklistItem(text: "Blackened"),
+            ChecklistItem(text: "Pork"),
+            ChecklistItem(text: "Alcohol"),
+            ChecklistItem(text: "Nuts"),
+            ChecklistItem(text: "Without pork")
+        ]
     }
 
     func filterList(for fliter: Filter) -> [ChecklistItem] {
@@ -118,10 +104,10 @@ class FilterList {
     }
 }
 
-class ChecklistItem: NSObject {
-    @objc var text = ""
+struct ChecklistItem {
+    let text: String
     var checked = false
-    func toggleChecked() {
-        checked = !checked
+    mutating func toggleChecked() {
+        checked.toggle()
     }
 }

--- a/iOSApp/Uni Saar/NetworkingAndSessionManager/APIClient.swift
+++ b/iOSApp/Uni Saar/NetworkingAndSessionManager/APIClient.swift
@@ -46,7 +46,7 @@ class APIClient {
                 afError.isParameterEncodingError || afError.isResponseValidationError {
                 throw AppError.networkFailure
             }
-            throw AppError.networkFailure
+            throw afError.underlyingError ?? AppError.networkFailure
         }
     }
 

--- a/iOSApp/Uni Saar/NetworkingAndSessionManager/APIClient.swift
+++ b/iOSApp/Uni Saar/NetworkingAndSessionManager/APIClient.swift
@@ -40,13 +40,13 @@ class APIClient {
             APIClient.printL("Error while fetching data: \(afError)", type: .error)
             if let responseData = response.data,
                let jsonMessage = String(data: responseData, encoding: .utf8), !jsonMessage.isEmpty {
-                throw LLError(status: false, message: jsonMessage)
+                throw AppError.serverMessage(jsonMessage)
             }
             if afError.isResponseSerializationError || afError.isInvalidURLError ||
                 afError.isParameterEncodingError || afError.isResponseValidationError {
-                throw MyError.customError
+                throw AppError.networkFailure
             }
-            throw afError
+            throw AppError.networkFailure
         }
     }
 

--- a/iOSApp/Uni Saar/NetworkingAndSessionManager/LLError.swift
+++ b/iOSApp/Uni Saar/NetworkingAndSessionManager/LLError.swift
@@ -6,122 +6,16 @@
 //  Copyright © 2019 Ali Al-Hasani. All rights reserved.
 //
 
-import Alamofire
 import Foundation
 
-/// our own custom class error handler, to show more friendly error networking/server messages
-final class LLError: NSObject, Error {
-    let status: Bool
-    let message: String
-    init(status: Bool?, message: String) {
-        self.status = status ?? true
-        self.message = message
-    }
-}
+enum AppError: LocalizedError {
+    case serverMessage(String)
+    case networkFailure
 
-extension LLError: LocalizedError {
     var errorDescription: String? {
-        message
-    }
-}
-
-public enum MyError: Error {
-    case customError
-}
-
-extension MyError: LocalizedError {
-    public var errorDescription: String? {
         switch self {
-        case .customError:
-            NSLocalizedString("generalAPIError", comment: "My error")
+        case let .serverMessage(message): message
+        case .networkFailure: NSLocalizedString("generalAPIError", comment: "")
         }
-    }
-}
-
-/// case invalidURL(url: URLConvertible)
-/// case parameterEncodingFailed(reason: ParameterEncodingFailureReason)
-/// case multipartEncodingFailed(reason: MultipartEncodingFailureReason)
-/// case responseValidationFailed(reason: ResponseValidationFailureReason)
-/// case responseSerializationFailed(reason: ResponseSerializationFailureReason)
-public extension AFError {
-    var myCustomErrorReasons: String {
-        if case let .parameterEncodingFailed(reason) = self {
-            switch reason {
-            case .missingURL:
-                return "parameter Encoding Failed, missing URL"
-            case .jsonEncodingFailed:
-                return "parameter Encoding Failed, json Encoding Failed"
-            default:
-                return "parameter Encoding Failed"
-            }
-            // return "parameter Encoding Failed"
-        } else if case let .multipartEncodingFailed(reason) = self {
-            switch reason {
-            case let .bodyPartURLInvalid(url):
-                return "multipartEncodingFailed, bodyPartURLInvalid , \(url)"
-            case let .bodyPartFilenameInvalid(url):
-                return "multipartEncodingFailed, bodyPartFilenameInvalid , \(url)"
-            case let .bodyPartFileNotReachable(url):
-                return "multipartEncodingFailed, bodyPartFileNotReachable , \(url)"
-            case let .bodyPartFileNotReachableWithError(atURL, _):
-                return "multipartEncodingFailed, bodyPartFileNotReachableWithError , \(atURL)"
-            case let .bodyPartFileIsDirectory(url):
-                return "multipartEncodingFailed, bodyPartFileIsDirectory , \(url)"
-            case let .bodyPartFileSizeNotAvailable(url):
-                return "multipartEncodingFailed, bodyPartFileSizeNotAvailable , \(url)"
-            case let .bodyPartFileSizeQueryFailedWithError(forURL, _):
-                return "multipartEncodingFailed, bodyPartFileSizeQueryFailedWithError , \(forURL)"
-            case let .bodyPartInputStreamCreationFailed(url):
-                return "multipartEncodingFailed, bodyPartInputStreamCreationFailed , \(url)"
-            case let .outputStreamCreationFailed(url):
-                return "multipartEncodingFailed, outputStreamCreationFailed , \(url)"
-            case let .outputStreamFileAlreadyExists(url):
-                return "multipartEncodingFailed, outputStreamFileAlreadyExists , \(url)"
-            case let .outputStreamURLInvalid(url):
-                return "multipartEncodingFailed, outputStreamURLInvalid , \(url)"
-            case .outputStreamWriteFailed:
-                return "multipartEncodingFailed, outputStreamWriteFailed"
-            case .inputStreamReadFailed:
-                return "multipartEncodingFailed, inputStreamReadFailed."
-            }
-            // return "multipart Encoding Failed"
-        } else if case let .responseSerializationFailed(reason) = self {
-            switch reason {
-            case .inputDataNilOrZeroLength:
-                return "responseSerializationFailed, inputDataNilOrZeroLength."
-            case .inputFileNil:
-                return "responseSerializationFailed, inputFileNil."
-            case let .inputFileReadFailed(atLocation):
-                return "responseSerializationFailed, inputFileReadFailed. , \(atLocation)"
-            case let .stringSerializationFailed(encoding):
-                return "responseSerializationFailed, stringSerializationFailed., \(encoding.description)"
-            case .jsonSerializationFailed:
-                return "responseSerializationFailed, jsonSerializationFailed"
-            default:
-                return "responseSerializationFailed"
-            }
-            // return "response Serialization Failed"
-        } else if case let .responseValidationFailed(reason) = self {
-            switch reason {
-            case .dataFileNil:
-                return "responseValidationFailed, dataFileNil."
-            case let .dataFileReadFailed(atLocation):
-                return "responseValidationFailed, dataFileReadFailed. , \(atLocation)"
-            case let .missingContentType(acceptableContentTypes):
-                return "responseValidationFailed, missingContentType. , \(acceptableContentTypes)"
-            case let .unacceptableContentType(acceptableContentTypes, _):
-                return "responseValidationFailed, unacceptableContentType. , \(acceptableContentTypes)"
-            case let .unacceptableStatusCode(code):
-                return "responseValidationFailed, unacceptableStatusCode. , \(code)"
-            case let .customValidationFailed(error):
-                return "responseValidationFailed, customValidationFailed. , \(error)"
-            default:
-                return "responseValidationFailed"
-            }
-            // return "response Validation Failed"
-        } else if case let .invalidURL(url) = self {
-            return "invalid URL , \(url)"
-        }
-        return "Unknown Error"
     }
 }

--- a/iOSApp/Uni Saar/ViewModels/DirectoryViewModel.swift
+++ b/iOSApp/Uni Saar/ViewModels/DirectoryViewModel.swift
@@ -53,7 +53,7 @@ class DirectoryViewModel: ParentViewModel {
         } catch {
             showLoadingIndicator = false
             searchResutlsCells = [.error(message: error.localizedDescription)]
-            if !(error is LLError) {
+            if !(error is AppError) {
                 showError(error: error)
             }
         }

--- a/iOSApp/Uni Saar/ViewModels/FilterMensaViewModel.swift
+++ b/iOSApp/Uni Saar/ViewModels/FilterMensaViewModel.swift
@@ -189,7 +189,7 @@ extension FilterMensaViewModel {
     }
 
     func notificationAlert() {
-        showError(error: LLError(status: true, message: NSLocalizedString("enableNotification", comment: "")))
+        showAlert(message: NSLocalizedString("enableNotification", comment: ""))
     }
 
     func loadFoodAlarmStatus() {

--- a/iOSApp/Uni Saar/ViewModels/ParentViewModel.swift
+++ b/iOSApp/Uni Saar/ViewModels/ParentViewModel.swift
@@ -24,7 +24,7 @@ class ParentViewModel {
         currentAlert = SingleButtonAlert(message: error?.localizedDescription, action: AlertAction(handler: nil, tryAgainHandler: tryAgainHandler))
     }
 
-    func showError(error: LLError?) {
-        currentAlert = SingleButtonAlert(message: error?.message, action: AlertAction(handler: nil, tryAgainHandler: nil))
+    func showAlert(message: String) {
+        currentAlert = SingleButtonAlert(message: message, action: AlertAction(handler: nil, tryAgainHandler: nil))
     }
 }

--- a/iOSApp/Uni Saar/ViewModels/ParentViewModel.swift
+++ b/iOSApp/Uni Saar/ViewModels/ParentViewModel.swift
@@ -29,4 +29,7 @@ class ParentViewModel {
         onAlert?(SingleButtonAlert(message: error?.localizedDescription, action: AlertAction(tryAgainHandler: onRetry)))
     }
 
+    func showAlert(message: String) {
+        onAlert?(SingleButtonAlert(message: message, action: AlertAction(tryAgainHandler: onRetry)))
+    }
 }

--- a/iOSApp/UniSaarTests/DirectoryViewModelTests.swift
+++ b/iOSApp/UniSaarTests/DirectoryViewModelTests.swift
@@ -54,7 +54,7 @@ final class DirectoryViewModelTests: XCTestCase {
 
     func testErrorDirectoryCells() async {
         let dataClient = MockAppDataClient()
-        dataClient.getSearchDirectoryResult = .failure(MyError.customError)
+        dataClient.getSearchDirectoryResult = .failure(AppError.networkFailure)
         let viewModel = DirectoryViewModel(dataClient: dataClient)
         await viewModel.loadGetSearchResults(searchQuery: "")
         guard case .error = viewModel.searchResutlsCells.first else {
@@ -112,7 +112,7 @@ final class DirectoryViewModelTests: XCTestCase {
 
     func testErrorHelpfulNumberCells() async {
         let dataClient = MockAppDataClient()
-        dataClient.getHelpfulNumbersResult = .failure(MyError.customError)
+        dataClient.getHelpfulNumbersResult = .failure(AppError.networkFailure)
         let viewModel = DirectoryViewModel(dataClient: dataClient)
         await viewModel.loadGetHelpHelpfulNumbers()
         guard case .error = viewModel.helpfulNumbersCells.first else {

--- a/iOSApp/UniSaarTests/EventViewModelTests.swift
+++ b/iOSApp/UniSaarTests/EventViewModelTests.swift
@@ -35,7 +35,7 @@ final class EventViewModelTests: XCTestCase {
 
     func testErrorEventCells() async {
         let dataClient = MockAppDataClient()
-        dataClient.getEventsResult = .failure(MyError.customError)
+        dataClient.getEventsResult = .failure(AppError.networkFailure)
         let viewModel = EventViewModel(dataClient: dataClient)
         await viewModel.loadGetEvents(month: "12", year: "2019")
         guard case .error = viewModel.eventCells.first else {

--- a/iOSApp/UniSaarTests/EventViewModelTests.swift
+++ b/iOSApp/UniSaarTests/EventViewModelTests.swift
@@ -21,7 +21,7 @@ final class EventViewModelTests: XCTestCase {
 
     func testSelectedDateEventsEmptyOnError() async {
         let dataClient = MockAppDataClient()
-        dataClient.getEventsResult = .failure(MyError.customError)
+        dataClient.getEventsResult = .failure(AppError.networkFailure)
         let viewModel = EventViewModel(dataClient: dataClient)
         await viewModel.loadGetEvents(month: "12", year: "2019")
         XCTAssertTrue(viewModel.selectedDateEvents.isEmpty)

--- a/iOSApp/UniSaarTests/FilterMensaViewModelTests.swift
+++ b/iOSApp/UniSaarTests/FilterMensaViewModelTests.swift
@@ -33,7 +33,7 @@ final class FilterMensaViewModelTests: XCTestCase {
 
     func testDidUpdateFilterListFalseOnError() async {
         let dataClient = MockAppDataClient()
-        dataClient.getMensaFilterResult = .failure(MyError.customError)
+        dataClient.getMensaFilterResult = .failure(AppError.networkFailure)
         let viewModel = FilterMensaViewModel(dataClient: dataClient)
         await viewModel.loadGetFilterList()
         XCTAssertFalse(viewModel.didUpdatefilterList)
@@ -41,7 +41,7 @@ final class FilterMensaViewModelTests: XCTestCase {
 
     func testCurrentAlertOnError() async {
         let dataClient = MockAppDataClient()
-        dataClient.getMensaFilterResult = .failure(MyError.customError)
+        dataClient.getMensaFilterResult = .failure(AppError.networkFailure)
         let viewModel = FilterMensaViewModel(dataClient: dataClient)
         await viewModel.loadGetFilterList()
         XCTAssertNotNil(viewModel.currentAlert)

--- a/iOSApp/UniSaarTests/FilterNewsViewModelTests.swift
+++ b/iOSApp/UniSaarTests/FilterNewsViewModelTests.swift
@@ -24,7 +24,7 @@ final class FilterNewsViewModelTests: XCTestCase {
 
     func testDidUpdateFilterListFalseOnError() async {
         let dataClient = MockAppDataClient()
-        dataClient.getNewsCategoriesResult = .failure(MyError.customError)
+        dataClient.getNewsCategoriesResult = .failure(AppError.networkFailure)
         let viewModel = FilterNewsViewModel(dataClient: dataClient)
         await viewModel.loadGetFilterList()
         XCTAssertFalse(viewModel.didUpdatefilterList)
@@ -32,7 +32,7 @@ final class FilterNewsViewModelTests: XCTestCase {
 
     func testCurrentAlertOnError() async {
         let dataClient = MockAppDataClient()
-        dataClient.getNewsCategoriesResult = .failure(MyError.customError)
+        dataClient.getNewsCategoriesResult = .failure(AppError.networkFailure)
         let viewModel = FilterNewsViewModel(dataClient: dataClient)
         await viewModel.loadGetFilterList()
         XCTAssertNotNil(viewModel.currentAlert)

--- a/iOSApp/UniSaarTests/MensaViewModelTests.swift
+++ b/iOSApp/UniSaarTests/MensaViewModelTests.swift
@@ -45,7 +45,7 @@ final class MensaViewModelTests: XCTestCase {
 
     func testErrorMensaCells() async {
         let dataClient = MockAppDataClient()
-        dataClient.getMensaResult = .failure(MyError.customError)
+        dataClient.getMensaResult = .failure(AppError.networkFailure)
         let viewModel = MensaMenuViewModel(dataClient: dataClient)
         await viewModel.loadGetMensaMenu()
         guard case .error = viewModel.daysMenus.first else {
@@ -103,7 +103,7 @@ final class MensaViewModelTests: XCTestCase {
 
     func testErrorMealDetails() async {
         let dataClient = MockAppDataClient()
-        dataClient.getMealResult = .failure(MyError.customError)
+        dataClient.getMealResult = .failure(AppError.networkFailure)
         let viewModel = MealDetailsViewModel(dataClient: dataClient)
         await viewModel.loadGetMealDetails(mealId: 1)
         XCTAssertNil(viewModel.mealDetails.mealDetailsModel, "Mensa meal details request should be failed and return empty model")

--- a/iOSApp/UniSaarTests/MoreViewModelTests.swift
+++ b/iOSApp/UniSaarTests/MoreViewModelTests.swift
@@ -50,7 +50,7 @@ final class MoreViewModelTests: XCTestCase {
 
     func testErrorMoreLinksCells() async {
         let dataClient = MockAppDataClient()
-        dataClient.getMoreLinksResult = .failure(MyError.customError)
+        dataClient.getMoreLinksResult = .failure(AppError.networkFailure)
         let viewModel = MoreLinksViewModel(dataClient: dataClient)
         await viewModel.loadGetMoreLinks()
         if case .error = viewModel.linksCells.first {

--- a/iOSApp/UniSaarTests/NewsViewModelTests.swift
+++ b/iOSApp/UniSaarTests/NewsViewModelTests.swift
@@ -34,7 +34,7 @@ final class NewsViewModelTests: XCTestCase {
 
     func testErrorNewsCells() async {
         let dataClient = MockAppDataClient()
-        dataClient.getNewsResult = .failure(MyError.customError)
+        dataClient.getNewsResult = .failure(AppError.networkFailure)
         let viewModel = NewsFeedViewModel(dataClient: dataClient)
         await viewModel.loadGetNews(filterCatgroies: [])
         guard case .error = viewModel.newsCells.first else { XCTFail("Expected error cell"); return }

--- a/iOSApp/UniSaarTests/ObservableTest.swift
+++ b/iOSApp/UniSaarTests/ObservableTest.swift
@@ -14,14 +14,14 @@ final class ObservationTests: XCTestCase {
     /// showError is synchronous — no async needed
     func testCurrentAlertSetOnError() {
         let viewModel = NewsFeedViewModel()
-        viewModel.showError(error: MyError.customError)
+        viewModel.showError(error: AppError.networkFailure)
         XCTAssertNotNil(viewModel.currentAlert)
         XCTAssertNotNil(viewModel.currentAlert?.message)
     }
 
-    func testCurrentAlertSetOnLLError() {
+    func testCurrentAlertSetOnServerError() {
         let viewModel = NewsFeedViewModel()
-        viewModel.showError(error: LLError(status: false, message: "test error"))
+        viewModel.showError(error: AppError.serverMessage("test error"))
         XCTAssertNotNil(viewModel.currentAlert)
         XCTAssertNotNil(viewModel.currentAlert?.message)
     }

--- a/iOSApp/UniSaarTests/StaffDetailsViewModelTests.swift
+++ b/iOSApp/UniSaarTests/StaffDetailsViewModelTests.swift
@@ -34,7 +34,7 @@ final class StaffDetailsViewModelTests: XCTestCase {
 
     func testStaffDetailsError() async {
         let dataClient = MockAppDataClient()
-        dataClient.getStaffDetailsResult = .failure(MyError.customError)
+        dataClient.getStaffDetailsResult = .failure(AppError.networkFailure)
         let viewModel = StaffDetailsViewModel(dataClient: dataClient)
         await viewModel.loadGetStaffDetails(staffId: 1)
         XCTAssertNil(viewModel.staffDetails.staffDetailsModel)

--- a/iOSApp/UniSaarTests/UpdatePropertiesLifecycleTests.swift
+++ b/iOSApp/UniSaarTests/UpdatePropertiesLifecycleTests.swift
@@ -98,7 +98,7 @@ final class UpdatePropertiesLifecycleTests: XCTestCase {
         viewController.setupTableView()
 
         let dataClient = MockAppDataClient()
-        dataClient.getNewsResult = .failure(MyError.customError)
+        dataClient.getNewsResult = .failure(AppError.networkFailure)
         viewController.newsViewModel = NewsFeedViewModel(dataClient: dataClient)
         await viewController.newsViewModel.loadGetNews(filterCatgroies: [])
 
@@ -225,7 +225,7 @@ final class UpdatePropertiesLifecycleTests: XCTestCase {
         viewController.viewDidLoad()
 
         let dataClient = MockAppDataClient()
-        dataClient.getMealResult = .failure(MyError.customError)
+        dataClient.getMealResult = .failure(AppError.networkFailure)
         viewController.meal = MealDetailsViewModel(dataClient: dataClient)
         await viewController.meal.loadGetMealDetails(mealId: 1)
 
@@ -276,7 +276,7 @@ final class UpdatePropertiesLifecycleTests: XCTestCase {
         viewController.viewDidLoad()
 
         let dataClient = MockAppDataClient()
-        dataClient.getStaffDetailsResult = .failure(MyError.customError)
+        dataClient.getStaffDetailsResult = .failure(AppError.networkFailure)
         viewController.staff = StaffDetailsViewModel(dataClient: dataClient)
         await viewController.staff.loadGetStaffDetails(staffId: 1)
 


### PR DESCRIPTION
Two unrelated NSObject/ObjC-style types replaced with plain Swift value types. 

- Replaced `LLError` + `MyError` with a single `AppError` enum for both server and network failures
-  conforms to `LocalizedError`, implicitly Sendable in Swift 6
- `APIClient` now throws `AppError` at all three error paths — raw AFError strings no longer reach the UI

Completes Issue #32 2-3

Known gaps:
- `NSLocalizedString` calls remain throughout — migration to `String(localized:)` deferred to a separate PR 