### PR TITLE
refactor/session-manager: @Observable AppSessionManager with didSet auto-persistence

### DIFF
--- a/iOSApp/Uni Saar/AppDelegate.swift
+++ b/iOSApp/Uni Saar/AppDelegate.swift
@@ -50,18 +50,12 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         // If any sessions were discarded while the application was not running, this will be called shortly after application:didFinishLaunchingWithOptions.
         // Use this method to release any resources that were specific to the discarded scenes, as they will not return.
         //         CoreDataStack.sharedInstance.saveContext()
-        //         AppSessionManager.saveMensafiltersStatus()
     }
 
     /// Fallback on earlier versions
     func applicationWillTerminate(_ application: UIApplication) {
         // Called when the application is about to terminate. Save data if appropriate. See also applicationDidEnterBackground:.
         CoreDataStack.sharedInstance.saveContext()
-        AppSessionManager.saveMensafiltersStatus()
-        AppSessionManager.saveNewsfiltersStatus()
-        AppSessionManager.saveMoreLinksStatus()
-        AppSessionManager.saveHelpfulNumberStatus()
-        AppSessionManager.saveFoodAlarmStatus()
     }
 }
 

--- a/iOSApp/Uni Saar/NetworkingAndSessionManager/AppSessionManager.swift
+++ b/iOSApp/Uni Saar/NetworkingAndSessionManager/AppSessionManager.swift
@@ -19,27 +19,35 @@ class AppSessionManager {
     var dismissWelcomeScreen: Bool {
         didSet { defaults.set(dismissWelcomeScreen, forKey: Self.skipWelcomeScreenKey) }
     }
+
     var selectedCampus: Campus {
         didSet { defaults.set(selectedCampus.rawValue, forKey: Self.selectedCampusKey) }
     }
+
     var selectedMensaLocation: Campus {
         didSet { defaults.set(selectedMensaLocation.rawValue, forKey: Self.selectedMensaLocationKey) }
     }
+
     var mensafiltersLastChanged: String? {
         didSet { defaults.set(mensafiltersLastChanged, forKey: Self.mensafiltersLastChangedKey) }
     }
+
     var newsFiltersLastChanged: String? {
         didSet { defaults.set(newsFiltersLastChanged, forKey: Self.newsFiltersLastChangedKey) }
     }
+
     var morelinksLastChanged: String {
         didSet { defaults.set(morelinksLastChanged, forKey: Self.linksLastChangedKey) }
     }
+
     var helpfulNumbersLastChanged: String {
         didSet { defaults.set(helpfulNumbersLastChanged, forKey: Self.helpfulNumbersLastChangedKey) }
     }
+
     var isFoodAlarmEnabled: Bool {
         didSet { defaults.set(isFoodAlarmEnabled, forKey: Self.foodAlarmStatusKey) }
     }
+
     var foodAlarmTime: Date? {
         didSet { defaults.set(foodAlarmTime, forKey: Self.foodAlarmTimeKey) }
     }

--- a/iOSApp/Uni Saar/NetworkingAndSessionManager/AppSessionManager.swift
+++ b/iOSApp/Uni Saar/NetworkingAndSessionManager/AppSessionManager.swift
@@ -7,125 +7,71 @@
 //
 
 import Foundation
+import Observation
 
-/// todo later
 @MainActor
+@Observable
 class AppSessionManager {
-    var dismissWelcomeScreen: Bool = false
-    var selectedCampus: Campus = .saarbruken
-    var selectedMensaLocation: Campus = .saarbruken
-    var isEventEnabled = false
-    // api last updated date
-    var mensafiltersLastChanged: String?
-    var newsFiltersLastChanged: String?
-    var morelinksLastChanged: String = "never"
-    var helpfulNumbersLastChanged: String = "never"
-    var coordinateLastChanged: String = ""
-    var isFoodAlarmEnabled: Bool = false
-    var foodAlarmTime: Date?
-    // to avoid fetchFilterListFromStorage more than one time in the run app run time
+    static let shared = AppSessionManager()
+
+    // MARK: - Persisted
+
+    var dismissWelcomeScreen: Bool {
+        didSet { defaults.set(dismissWelcomeScreen, forKey: Self.skipWelcomeScreenKey) }
+    }
+    var selectedCampus: Campus {
+        didSet { defaults.set(selectedCampus.rawValue, forKey: Self.selectedCampusKey) }
+    }
+    var selectedMensaLocation: Campus {
+        didSet { defaults.set(selectedMensaLocation.rawValue, forKey: Self.selectedMensaLocationKey) }
+    }
+    var mensafiltersLastChanged: String? {
+        didSet { defaults.set(mensafiltersLastChanged, forKey: Self.mensafiltersLastChangedKey) }
+    }
+    var newsFiltersLastChanged: String? {
+        didSet { defaults.set(newsFiltersLastChanged, forKey: Self.newsFiltersLastChangedKey) }
+    }
+    var morelinksLastChanged: String {
+        didSet { defaults.set(morelinksLastChanged, forKey: Self.linksLastChangedKey) }
+    }
+    var helpfulNumbersLastChanged: String {
+        didSet { defaults.set(helpfulNumbersLastChanged, forKey: Self.helpfulNumbersLastChangedKey) }
+    }
+    var isFoodAlarmEnabled: Bool {
+        didSet { defaults.set(isFoodAlarmEnabled, forKey: Self.foodAlarmStatusKey) }
+    }
+    var foodAlarmTime: Date? {
+        didSet { defaults.set(foodAlarmTime, forKey: Self.foodAlarmTimeKey) }
+    }
+
+    // MARK: - Session-only (reset each launch)
+
     var isMensaFiltersCacheFetched = false
-    class var shared: AppSessionManager {
-        struct Static {
-            static let instance = AppSessionManager()
-        }
-        return Static.instance
-    }
 
-    // save the status of first opening setup screens, to not show it later
-    static let skipWelcomeScreenKey = "skipWelcomeScreen"
-    static let mensafiltersLastChangedKey = "mensafiltersLastChanged"
-    static let newsFiltersLastChangedKey = "newsFiltersLastChanged"
-    static let linksLastChangedKey = "linksLastChangedKey"
-    static let helpfulNumbersLastChangedKey = "helpfulNumbersLastChanged"
-    static let foodAlarmStatusKey = "foodAlarmStatusKey"
-    static let foodAlarmTimeKey = "foodAlarmTimeKey"
-    static let selectedCampusKey = "selectedCampusKey"
-    static let selectedMensaLocationKey = "selectedMensaLocationKey"
-}
+    // MARK: - Private
 
-/// cache functions
-extension AppSessionManager {
-    class func saveWelcomeScreenStatus() {
-        let skipWelcomeScreen = AppSessionManager.shared.dismissWelcomeScreen
-        UserDefaults.standard.set(skipWelcomeScreen, forKey: skipWelcomeScreenKey)
-    }
+    @ObservationIgnored private let defaults: UserDefaults
 
-    class func loadWelcomeScreenStatus() {
-        AppSessionManager.shared.dismissWelcomeScreen = UserDefaults.standard.bool(forKey: skipWelcomeScreenKey)
-    }
+    private static let skipWelcomeScreenKey = "skipWelcomeScreen"
+    private static let selectedCampusKey = "selectedCampusKey"
+    private static let selectedMensaLocationKey = "selectedMensaLocationKey"
+    private static let mensafiltersLastChangedKey = "mensafiltersLastChanged"
+    private static let newsFiltersLastChangedKey = "newsFiltersLastChanged"
+    private static let linksLastChangedKey = "linksLastChangedKey"
+    private static let helpfulNumbersLastChangedKey = "helpfulNumbersLastChanged"
+    private static let foodAlarmStatusKey = "foodAlarmStatusKey"
+    private static let foodAlarmTimeKey = "foodAlarmTimeKey"
 
-    class func saveMensafiltersStatus() {
-        let mensafiltersLastChanged = AppSessionManager.shared.mensafiltersLastChanged
-        UserDefaults.standard.set(mensafiltersLastChanged, forKey: mensafiltersLastChangedKey)
-    }
-
-    class func loadMensafiltersStatus() {
-        guard let tempType = UserDefaults.standard.string(forKey: mensafiltersLastChangedKey) else { return }
-        AppSessionManager.shared.mensafiltersLastChanged = tempType
-    }
-
-    class func saveNewsfiltersStatus() {
-        let newsFiltersLastChanged = AppSessionManager.shared.newsFiltersLastChanged
-        UserDefaults.standard.set(newsFiltersLastChanged, forKey: newsFiltersLastChangedKey)
-    }
-
-    class func loadNewsfiltersStatus() {
-        guard let tempType = UserDefaults.standard.string(forKey: newsFiltersLastChangedKey) else { return }
-        AppSessionManager.shared.newsFiltersLastChanged = tempType
-    }
-
-    class func saveMoreLinksStatus() {
-        let morelinksLastChanged = AppSessionManager.shared.morelinksLastChanged
-        UserDefaults.standard.set(morelinksLastChanged, forKey: linksLastChangedKey)
-    }
-
-    class func loadMoreLinksStatus() {
-        guard let tempType = UserDefaults.standard.string(forKey: linksLastChangedKey) else { return }
-        AppSessionManager.shared.morelinksLastChanged = tempType
-    }
-
-    class func saveHelpfulNumberStatus() {
-        let helpfulNumbersLastChange = AppSessionManager.shared.helpfulNumbersLastChanged
-        UserDefaults.standard.set(helpfulNumbersLastChange, forKey: helpfulNumbersLastChangedKey)
-    }
-
-    class func loadHelpfulNumberStatus() {
-        guard let tempType = UserDefaults.standard.string(forKey: helpfulNumbersLastChangedKey) else { return }
-        AppSessionManager.shared.helpfulNumbersLastChanged = tempType
-    }
-
-    class func saveFoodAlarmStatus() {
-        let foodAlarmStatus = AppSessionManager.shared.isFoodAlarmEnabled
-        UserDefaults.standard.set(foodAlarmStatus, forKey: foodAlarmStatusKey)
-
-        let foodAlarmTime = AppSessionManager.shared.foodAlarmTime
-        UserDefaults.standard.set(foodAlarmTime, forKey: foodAlarmTimeKey)
-    }
-
-    class func loadFoodAlarmTime() {
-        AppSessionManager.shared.isFoodAlarmEnabled = UserDefaults.standard.bool(forKey: foodAlarmStatusKey)
-        AppSessionManager.shared.foodAlarmTime = UserDefaults.standard.object(forKey: foodAlarmTimeKey) as? Date
-    }
-
-    class func saveCampuslocation() {
-        let campuslocation = AppSessionManager.shared.selectedCampus.locationKey
-        UserDefaults.standard.set(campuslocation, forKey: selectedCampusKey)
-
-        let mensaLocation = AppSessionManager.shared.selectedMensaLocation.locationKey
-        UserDefaults.standard.set(mensaLocation, forKey: selectedMensaLocationKey)
-    }
-
-    class func loadCampuslocation() {
-        guard let campuslocation = UserDefaults.standard.string(forKey: selectedCampusKey) else { return }
-        AppSessionManager.shared.selectedCampus = Campus(rawValue: campuslocation) ?? .saarbruken
-
-        guard let mensaLocation = UserDefaults.standard.string(forKey: selectedMensaLocationKey) else { return }
-        AppSessionManager.shared.selectedMensaLocation = Campus(rawValue: mensaLocation) ?? .saarbruken
-        notifyCampusView()
-    }
-
-    class func notifyCampusView() {
-        NotificationCenter.default.post(name: NSNotification.Name(rawValue: "CampusSettingsDidUpdate"), object: nil)
+    init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+        dismissWelcomeScreen = defaults.bool(forKey: Self.skipWelcomeScreenKey)
+        selectedCampus = Campus(rawValue: defaults.string(forKey: Self.selectedCampusKey) ?? "") ?? .saarbruken
+        selectedMensaLocation = Campus(rawValue: defaults.string(forKey: Self.selectedMensaLocationKey) ?? "") ?? .saarbruken
+        mensafiltersLastChanged = defaults.string(forKey: Self.mensafiltersLastChangedKey)
+        newsFiltersLastChanged = defaults.string(forKey: Self.newsFiltersLastChangedKey)
+        morelinksLastChanged = defaults.string(forKey: Self.linksLastChangedKey) ?? "never"
+        helpfulNumbersLastChanged = defaults.string(forKey: Self.helpfulNumbersLastChangedKey) ?? "never"
+        isFoodAlarmEnabled = defaults.bool(forKey: Self.foodAlarmStatusKey)
+        foodAlarmTime = defaults.object(forKey: Self.foodAlarmTimeKey) as? Date
     }
 }

--- a/iOSApp/Uni Saar/SceneDelegate.swift
+++ b/iOSApp/Uni Saar/SceneDelegate.swift
@@ -13,18 +13,8 @@ class MediatorDelegate: UIResponder {
     static var window: UIWindow?
     static var sceneDelegate: SceneDelegate?
     static func configureRootViewController(window: UIWindow?, sceneDelegate: SceneDelegate? = nil) {
-        AppSessionManager.loadWelcomeScreenStatus()
         MediatorDelegate.sceneDelegate = sceneDelegate
-        // DispatchQueue.main.async {
-        AppSessionManager.loadCampuslocation()
-        AppSessionManager.loadMensafiltersStatus()
-        AppSessionManager.loadNewsfiltersStatus()
-        AppSessionManager.loadMoreLinksStatus()
-        AppSessionManager.loadHelpfulNumberStatus()
-        // }
-        if !AppSessionManager.shared.dismissWelcomeScreen, window?.rootViewController is AppSetupFirstScreenViewController {
-            return
-        } else {
+        if AppSessionManager.shared.dismissWelcomeScreen {
             navigateToMainHomeScreen(window: window)
         }
     }

--- a/iOSApp/Uni Saar/ViewControllers/CampusViewControllers/CampusViewController.swift
+++ b/iOSApp/Uni Saar/ViewControllers/CampusViewControllers/CampusViewController.swift
@@ -31,7 +31,7 @@ class CampusViewController: UIViewController {
         selectedCampus = AppSessionManager.shared.selectedCampus
         campusCoor = CampusModel(filename: AppSessionManager.shared.selectedCampus.mapCoorFileName)
         setUpSearchBar()
-        setupNotification()
+        setupCampusObservation()
         mapView.register(MKMarkerAnnotationView.self, forAnnotationViewWithReuseIdentifier: MKMapViewDefaultAnnotationViewReuseIdentifier)
     }
 
@@ -80,8 +80,15 @@ class CampusViewController: UIViewController {
         }
     }
 
-    func setupNotification() {
-        NotificationCenter.default.addObserver(self, selector: #selector(updateCampus), name: NSNotification.Name("CampusSettingsDidUpdate"), object: nil)
+    func setupCampusObservation() {
+        withObservationTracking {
+            _ = AppSessionManager.shared.selectedCampus
+        } onChange: { [weak self] in
+            Task { @MainActor [weak self] in
+                self?.updateCampus()
+                self?.setupCampusObservation()
+            }
+        }
     }
 
     func loadCoordinates(checkForUpdate: Bool = true) -> [MapInfoModel] {
@@ -100,13 +107,12 @@ class CampusViewController: UIViewController {
         mapItem.openInMaps(launchOptions: nil)
     }
 
-    @objc func updateCampus() {
+    func updateCampus() {
         didChangeLocationFilter(selectedCampus: AppSessionManager.shared.selectedCampus, regionNeedUpdate: true)
     }
 
     func saveLocation() {
         AppSessionManager.shared.selectedCampus = selectedCampus
-        AppSessionManager.saveCampuslocation()
     }
 
     func updateCoordinateCache(lastChangedDate: String) {

--- a/iOSApp/Uni Saar/ViewControllers/MensaViewControllers/FilterMensaViewController.swift
+++ b/iOSApp/Uni Saar/ViewControllers/MensaViewControllers/FilterMensaViewController.swift
@@ -54,7 +54,6 @@ class FilterMensaViewController: UIViewController {
         super.viewWillDisappear(animated)
         loadTask?.cancel()
         AppSessionManager.shared.foodAlarmTime = filterMensaViewModel.selectedAlramTime
-        AppSessionManager.saveFoodAlarmStatus()
     }
 
     private func setupViewModel() {

--- a/iOSApp/Uni Saar/ViewControllers/MoreViewControllers/SettingsViewController.swift
+++ b/iOSApp/Uni Saar/ViewControllers/MoreViewControllers/SettingsViewController.swift
@@ -37,11 +37,9 @@ class SettingsViewController: UITableViewController {
             if indexPath.section == 0, indexPath.row == 0 {
                 cell.accessoryType = .checkmark
                 AppSessionManager.shared.selectedCampus = Campus.saarbruken
-                notifyCampusView()
             } else if indexPath.section == 0, indexPath.row == 1 {
                 cell.accessoryType = .checkmark
                 AppSessionManager.shared.selectedCampus = Campus.homburg
-                notifyCampusView()
             }
         }
     }
@@ -50,10 +48,6 @@ class SettingsViewController: UITableViewController {
         if let cell = tableView.cellForRow(at: indexPath) {
             cell.accessoryType = .none
         }
-    }
-
-    func notifyCampusView() {
-        NotificationCenter.default.post(name: NSNotification.Name(rawValue: "CampusSettingsDidUpdate"), object: nil)
     }
 
     func goToAppSettings() {

--- a/iOSApp/Uni Saar/ViewControllers/SteupViewControllers/AppSetupFirstScreenViewController.swift
+++ b/iOSApp/Uni Saar/ViewControllers/SteupViewControllers/AppSetupFirstScreenViewController.swift
@@ -79,7 +79,6 @@ class AppSetupFirstScreenViewController: UIViewController {
 
     func nextSessionWelcomeScreen() {
         AppSessionManager.shared.dismissWelcomeScreen = true
-        AppSessionManager.saveWelcomeScreenStatus()
     }
 
     func cacheCampusCoorFile() {

--- a/iOSApp/Uni Saar/ViewControllers/SteupViewControllers/SetupPrivacyViewController.swift
+++ b/iOSApp/Uni Saar/ViewControllers/SteupViewControllers/SetupPrivacyViewController.swift
@@ -14,16 +14,13 @@ class SetupPrivacyViewController: UIViewController {
     /// for remembering in next opening time to not open setup screen again
     func nextSessionWelcomeScreen() {
         AppSessionManager.shared.dismissWelcomeScreen = true
-        AppSessionManager.saveWelcomeScreenStatus()
     }
 
     @IBAction func acceptDataAction(_ sender: Any) {
-        AppSessionManager.shared.isEventEnabled = true
         nextScreen()
     }
 
     @IBAction func refuseShareDataAction(_ sender: Any) {
-        AppSessionManager.shared.isEventEnabled = false
         nextScreen()
     }
 


### PR DESCRIPTION
AppSessionManager was a plain class with manual `save*()`/`load*()` static functions called at app lifecycle boundaries. This replaces the whole pattern.

- Added `@Observable` —> properties are now reactive for SwiftUI Phase 3
- no save calls needed: `didSet` on each persisted property writes to UserDefaults immediately.
- no load calls needed: reads all persisted values at launch `init(defaults: UserDefaults = .standard)`

Completes Issue #32 2-3
Known gaps:
- Tests still hit `.shared` directly — `didSet` now writes to `UserDefaults.standard` on every `setUp` but couple of vm edits needed for full isolation fix -> deferred to its own PR.