### PR TITLE
iOS localization: replace NSLocalizedString with String(localized:)

### DIFF
--- a/iOSApp/Uni Saar/NetworkingAndSessionManager/AppStoreReviewManager.swift
+++ b/iOSApp/Uni Saar/NetworkingAndSessionManager/AppStoreReviewManager.swift
@@ -62,9 +62,9 @@ enum AppStoreReviewManager {
 
     @MainActor
     static func ratingDialogHandler(_ succesHandler: @escaping (UIAlertAction) -> Void) -> UIAlertController {
-        let alert = UIAlertController(title: NSLocalizedString("RateTitle", comment: ""), message: NSLocalizedString("EnjoyingAPP", comment: ""), preferredStyle: .alert)
-        alert.addAction(UIAlertAction(title: NSLocalizedString("RateYesActionTitle", comment: ""), style: .default, handler: succesHandler))
-        alert.addAction(UIAlertAction(title: NSLocalizedString("RateNoActionTitle", comment: ""), style: .cancel, handler: nil))
+        let alert = UIAlertController(title: String(localized: "RateTitle"), message: String(localized: "EnjoyingAPP"), preferredStyle: .alert)
+        alert.addAction(UIAlertAction(title: String(localized: "RateYesActionTitle"), style: .default, handler: succesHandler))
+        alert.addAction(UIAlertAction(title: String(localized: "RateNoActionTitle"), style: .cancel, handler: nil))
         return alert
     }
 }

--- a/iOSApp/Uni Saar/NetworkingAndSessionManager/LLError.swift
+++ b/iOSApp/Uni Saar/NetworkingAndSessionManager/LLError.swift
@@ -15,7 +15,7 @@ enum AppError: LocalizedError {
     var errorDescription: String? {
         switch self {
         case let .serverMessage(message): message
-        case .networkFailure: NSLocalizedString("generalAPIError", comment: "")
+        case .networkFailure: String(localized: "generalAPIError")
         }
     }
 }

--- a/iOSApp/Uni Saar/Supportive/SingleButtonAlert.swift
+++ b/iOSApp/Uni Saar/Supportive/SingleButtonAlert.swift
@@ -10,28 +10,28 @@ import Foundation
 import UIKit
 
 struct AlertAction {
-    let buttonTitle: String = NSLocalizedString("AlertOkActionTitle", comment: "")
-    let tryAgainButtonTitle: String = NSLocalizedString("tryAgain", comment: "")
+    let buttonTitle: String = .init(localized: "AlertOkActionTitle")
+    let tryAgainButtonTitle: String = .init(localized: "tryAgain")
     let tryAgainHandler: (@MainActor () -> Void)?
 }
 
 struct SingleButtonAlert {
-    let title: String = NSLocalizedString("AlertTitle", comment: "")
+    let title: String = .init(localized: "AlertTitle")
     let message: String?
     let action: AlertAction
 }
 
 extension UIViewController {
     func errorAlert(_ errorMessage: String) -> UIAlertController {
-        let alert = UIAlertController(title: NSLocalizedString("AlertTitle", comment: ""), message: errorMessage, preferredStyle: .alert)
-        alert.addAction(UIAlertAction(title: NSLocalizedString("AlertOkActionTitle", comment: ""), style: .default, handler: nil))
+        let alert = UIAlertController(title: String(localized: "AlertTitle"), message: errorMessage, preferredStyle: .alert)
+        alert.addAction(UIAlertAction(title: String(localized: "AlertOkActionTitle"), style: .default, handler: nil))
         return alert
     }
 
     func succesAlertWithHandler(_ errorMessage: String, _ handler: @escaping (UIAlertAction) -> Void) -> UIAlertController {
-        let alert = UIAlertController(title: NSLocalizedString("AlertTitle", comment: ""), message: errorMessage, preferredStyle: .alert)
-        alert.addAction(UIAlertAction(title: NSLocalizedString("AlertOkActionTitle", comment: ""), style: .default, handler: handler))
-        alert.addAction(UIAlertAction(title: NSLocalizedString("AlertCancelActionTitle", comment: ""), style: .cancel, handler: nil))
+        let alert = UIAlertController(title: String(localized: "AlertTitle"), message: errorMessage, preferredStyle: .alert)
+        alert.addAction(UIAlertAction(title: String(localized: "AlertOkActionTitle"), style: .default, handler: handler))
+        alert.addAction(UIAlertAction(title: String(localized: "AlertCancelActionTitle"), style: .cancel, handler: nil))
         return alert
     }
 }

--- a/iOSApp/Uni Saar/ViewControllers/CampusViewControllers/CampusViewController.swift
+++ b/iOSApp/Uni Saar/ViewControllers/CampusViewControllers/CampusViewController.swift
@@ -67,7 +67,7 @@ class CampusViewController: UIViewController {
             campusDelegate = buildingSearchTable
         }
         searchController.obscuresBackgroundDuringPresentation = false
-        searchController.searchBar.placeholder = NSLocalizedString("BuildingsSearch", comment: "")
+        searchController.searchBar.placeholder = String(localized: "BuildingsSearch")
         searchController.searchBar.searchTextField.backgroundColor = .systemBackground
         navigationItem.searchController = searchController
         activateSearchBar()

--- a/iOSApp/Uni Saar/ViewControllers/CampusViewControllers/ChooseCampusViewController.swift
+++ b/iOSApp/Uni Saar/ViewControllers/CampusViewControllers/ChooseCampusViewController.swift
@@ -68,7 +68,7 @@ extension ChooseCampusViewController: UITableViewDelegate, UITableViewDataSource
     }
 
     func tableView(_ tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
-        NSLocalizedString("ChooseCampus", comment: "")
+        String(localized: "ChooseCampus")
     }
 
     func tableView(_ tableView: UITableView, didDeselectRowAt indexPath: IndexPath) {

--- a/iOSApp/Uni Saar/ViewControllers/DirectoryViewControllers/DirectoryViewController.swift
+++ b/iOSApp/Uni Saar/ViewControllers/DirectoryViewControllers/DirectoryViewController.swift
@@ -54,7 +54,7 @@ class DirectoryViewController: UIViewController {
     func setupSearchBar() {
         searchController.searchResultsUpdater = self
         searchController.obscuresBackgroundDuringPresentation = false
-        searchController.searchBar.placeholder = NSLocalizedString("StaffSearch", comment: "")
+        searchController.searchBar.placeholder = String(localized: "StaffSearch")
         searchController.searchBar.searchTextField.backgroundColor = UIColor.appSystemBackgroundColor
         navigationItem.searchController = searchController
         definesPresentationContext = true
@@ -123,7 +123,7 @@ extension DirectoryViewController: UITableViewDelegate, UITableViewDataSource {
         case let .error(message):
             return defaultCell.setupEmptyCell(message: message)
         case .empty:
-            return defaultCell.setupEmptyCell(message: NSLocalizedString("EmptyResults", comment: ""))
+            return defaultCell.setupEmptyCell(message: String(localized: "EmptyResults"))
         case .none:
             return defaultCell
         }
@@ -142,7 +142,7 @@ extension DirectoryViewController: UITableViewDelegate, UITableViewDataSource {
         case let .error(message):
             return defaultCell.setupEmptyCell(message: message)
         case .empty:
-            return defaultCell.setupEmptyCell(message: NSLocalizedString("EmptyResults", comment: ""))
+            return defaultCell.setupEmptyCell(message: String(localized: "EmptyResults"))
         case .none:
             return defaultCell
         }
@@ -158,7 +158,7 @@ extension DirectoryViewController: UITableViewDelegate, UITableViewDataSource {
     }
 
     func tableView(_ tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
-        if !isSearching { return NSLocalizedString("HelpfulNumbers", comment: "") }
+        if !isSearching { return String(localized: "HelpfulNumbers") }
         return ""
     }
 }

--- a/iOSApp/Uni Saar/ViewControllers/DirectoryViewControllers/HelpfulContactsViewController.swift
+++ b/iOSApp/Uni Saar/ViewControllers/DirectoryViewControllers/HelpfulContactsViewController.swift
@@ -77,14 +77,14 @@ extension HelpfulContactsViewController: UITableViewDelegate, UITableViewDataSou
         case let .error(message):
             return defaultCell.setupEmptyCell(message: message)
         case .empty:
-            return defaultCell.setupEmptyCell(message: NSLocalizedString("EmptyResults", comment: ""))
+            return defaultCell.setupEmptyCell(message: String(localized: "EmptyResults"))
         case .none:
             return defaultCell
         }
     }
 
     func tableView(_ tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
-        NSLocalizedString("HelpfulNumbers", comment: "")
+        String(localized: "HelpfulNumbers")
     }
 }
 

--- a/iOSApp/Uni Saar/ViewControllers/MensaViewControllers/FilterMensaViewController.swift
+++ b/iOSApp/Uni Saar/ViewControllers/MensaViewControllers/FilterMensaViewController.swift
@@ -207,13 +207,13 @@ extension FilterMensaViewController: UITableViewDelegate, UITableViewDataSource 
         if let priority = filterForSectionIndex(section) {
             switch priority {
             case .location:
-                title = NSLocalizedString("MensaLocations", comment: "")
+                title = String(localized: "MensaLocations")
             case .empty:
-                title = NSLocalizedString("WarnMeAbout", comment: "")
+                title = String(localized: "WarnMeAbout")
             case .allergenList:
                 break
             case .foodAlram:
-                title = NSLocalizedString("MensaNotifications", comment: "")
+                title = String(localized: "MensaNotifications")
             }
         }
         return title
@@ -226,7 +226,7 @@ extension FilterMensaViewController: UITableViewDelegate, UITableViewDataSource 
             case .location:
                 break
             case .empty:
-                title = NSLocalizedString("HighlightAllergens", comment: "")
+                title = String(localized: "HighlightAllergens")
             case .allergenList:
                 break
             case .foodAlram:

--- a/iOSApp/Uni Saar/ViewControllers/MensaViewControllers/MensaCard/MensaCardViewController.swift
+++ b/iOSApp/Uni Saar/ViewControllers/MensaViewControllers/MensaCard/MensaCardViewController.swift
@@ -42,8 +42,8 @@ class MainViewController: UIViewController, NFCTagReaderSessionDelegate {
     @IBAction func scanCardAction() {
         guard NFCTagReaderSession.readingAvailable else {
             let alertController = UIAlertController(
-                title: NSLocalizedString("NFC Scanning Not Supported", comment: ""),
-                message: NSLocalizedString("This device doesn't support NFC tag scanning.", comment: ""),
+                title: String(localized: "NFC Scanning Not Supported"),
+                message: String(localized: "This device doesn't support NFC tag scanning."),
                 preferredStyle: .alert
             )
             alertController.addAction(UIAlertAction(title: "OK", style: .default, handler: nil))
@@ -52,7 +52,7 @@ class MainViewController: UIViewController, NFCTagReaderSessionDelegate {
         }
 
         session = NFCTagReaderSession(pollingOption: .iso14443, delegate: self)
-        session?.alertMessage = NSLocalizedString("Please hold your Student/Mensa card near the NFC sensor.", comment: "")
+        session?.alertMessage = String(localized: "Please hold your Student/Mensa card near the NFC sensor.")
         session?.begin()
     }
 

--- a/iOSApp/Uni Saar/ViewControllers/MensaViewControllers/MensaViewController.swift
+++ b/iOSApp/Uni Saar/ViewControllers/MensaViewControllers/MensaViewController.swift
@@ -145,7 +145,7 @@ extension MensaViewController: UICollectionViewDelegate, UICollectionViewDataSou
             else {
                 return UICollectionViewCell()
             }
-            cell.text = NSLocalizedString("emptyMenu", comment: "no menu")
+            cell.text = String(localized: "emptyMenu")
             return cell
         case .none:
             break

--- a/iOSApp/Uni Saar/ViewControllers/MoreViewControllers/AboutAppViewController.swift
+++ b/iOSApp/Uni Saar/ViewControllers/MoreViewControllers/AboutAppViewController.swift
@@ -28,8 +28,8 @@ class AboutAppViewController: UIViewController {
      */
 
     func setupGitHubLink() {
-        let fullString = NSLocalizedString("GitHubLinkText", comment: "")
-        let gitHubLinkRange = (fullString as NSString).range(of: NSLocalizedString("GitHub", comment: ""))
+        let fullString = String(localized: "GitHubLinkText")
+        let gitHubLinkRange = (fullString as NSString).range(of: String(localized: "GitHub"))
         let attributedStr = NSMutableAttributedString(string: fullString)
         attributedStr.addAttribute(.link, value: "gitHubLink", range: gitHubLinkRange)
         gitHubText.delegate = self

--- a/iOSApp/Uni Saar/ViewControllers/MoreViewControllers/MoreLinksViewController.swift
+++ b/iOSApp/Uni Saar/ViewControllers/MoreViewControllers/MoreLinksViewController.swift
@@ -96,7 +96,7 @@ extension MoreLinksViewController {
             case let .error(message):
                 return defaultCell.setupEmptyCell(message: message)
             case .empty:
-                return defaultCell.setupEmptyCell(message: NSLocalizedString("EmptyLinks", comment: ""))
+                return defaultCell.setupEmptyCell(message: String(localized: "EmptyLinks"))
             case .none:
                 return defaultCell
             }
@@ -116,9 +116,9 @@ extension MoreLinksViewController {
                 break
             }
         } else {
-            if moreLinksViewModel.extraCells[safe: indexPath.row] == NSLocalizedString("AppSettings", comment: "") {
+            if moreLinksViewModel.extraCells[safe: indexPath.row] == String(localized: "AppSettings") {
                 performSegue(withIdentifier: SegueIdentifiers.toSettings, sender: self)
-            } else if moreLinksViewModel.extraCells[safe: indexPath.row] == NSLocalizedString("AboutApp", comment: "") {
+            } else if moreLinksViewModel.extraCells[safe: indexPath.row] == String(localized: "AboutApp") {
                 performSegue(withIdentifier: SegueIdentifiers.toAboutApp, sender: self)
             }
         }

--- a/iOSApp/Uni Saar/ViewControllers/NewsFeedViewControllers/EventCalanderViewController.swift
+++ b/iOSApp/Uni Saar/ViewControllers/NewsFeedViewControllers/EventCalanderViewController.swift
@@ -155,7 +155,7 @@ extension EventCalanderViewController: UITableViewDelegate, UITableViewDataSourc
         case let .error(message):
             return defaultCell.setupEmptyCell(message: message)
         case .empty:
-            return defaultCell.setupEmptyCell(message: NSLocalizedString("EmptyEvents", comment: ""))
+            return defaultCell.setupEmptyCell(message: String(localized: "EmptyEvents"))
         case .none:
             return UITableViewCell()
         }

--- a/iOSApp/Uni Saar/ViewControllers/NewsFeedViewControllers/NewsFeedViewController.swift
+++ b/iOSApp/Uni Saar/ViewControllers/NewsFeedViewControllers/NewsFeedViewController.swift
@@ -120,7 +120,7 @@ extension NewsFeedViewController: UITableViewDelegate, UITableViewDataSource {
         case let .error(message):
             return defaultCell.setupEmptyCell(message: message)
         case .empty:
-            return defaultCell.setupEmptyCell(message: NSLocalizedString("EmptyNews", comment: ""))
+            return defaultCell.setupEmptyCell(message: String(localized: "EmptyNews"))
         case .none:
             return defaultCell
         }

--- a/iOSApp/Uni Saar/ViewModels/FilterMensaViewModel.swift
+++ b/iOSApp/Uni Saar/ViewModels/FilterMensaViewModel.swift
@@ -80,7 +80,7 @@ class FilterMensaViewModel: ParentViewModel {
         case .empty:
             []
         case .foodAlram:
-            [FilterElement(filterName: NSLocalizedString("EnableFoodAlarm", comment: ""),
+            [FilterElement(filterName: String(localized: "EnableFoodAlarm"),
                            filterID: "1", isSelected: isFoodAlarmEnabled), FilterElement(filterName: "", filterID: "2",
                                                                                          isSelected: false)]
         }
@@ -107,8 +107,8 @@ extension FilterMensaViewModel {
     func scheduleNotification() {
         let center = UNUserNotificationCenter.current()
         let content = UNMutableNotificationContent()
-        content.title = NSLocalizedString("TodayMensa", comment: "")
-        content.body = NSLocalizedString("NotificationBody", comment: "")
+        content.title = String(localized: "TodayMensa")
+        content.body = String(localized: "NotificationBody")
         content.categoryIdentifier = "alarm"
         content.sound = UNNotificationSound.default
 
@@ -180,7 +180,7 @@ extension FilterMensaViewModel {
     }
 
     func notificationAlert() {
-        showAlert(message: NSLocalizedString("enableNotification", comment: ""))
+        showAlert(message: String(localized: "enableNotification"))
     }
 
     func loadFoodAlarmStatus() {

--- a/iOSApp/Uni Saar/ViewModels/MensaViewModel.swift
+++ b/iOSApp/Uni Saar/ViewModels/MensaViewModel.swift
@@ -122,7 +122,7 @@ extension MensaMealsModel: MensaMealCellViewModel {
 
     @MainActor var noticesText: String {
         if noticesList.count > 0 {
-            AppStyle.warningTriangle + NSLocalizedString("contains", comment: "") + noticesList.compactMap(\.name).joined(separator: ", ")
+            AppStyle.warningTriangle + String(localized: "contains") + noticesList.compactMap(\.name).joined(separator: ", ")
         } else {
             ""
         }

--- a/iOSApp/Uni Saar/ViewModels/MoreLinksViewModel.swift
+++ b/iOSApp/Uni Saar/ViewModels/MoreLinksViewModel.swift
@@ -20,7 +20,7 @@ class MoreLinksViewModel: ParentViewModel {
                                           sectionNameKeyPath: nil, cacheName: nil)
     }()
 
-    let extraCells = [NSLocalizedString("AboutApp", comment: ""), NSLocalizedString("AppSettings", comment: "")]
+    let extraCells = [String(localized: "AboutApp"), String(localized: "AppSettings")]
 
     override init(dataClient: any AppDataClient = DataClient()) {
         super.init(dataClient: dataClient)

--- a/iOSApp/Uni Saar/Views/Cells/MensaNotificationTableViewCell.swift
+++ b/iOSApp/Uni Saar/Views/Cells/MensaNotificationTableViewCell.swift
@@ -29,6 +29,6 @@ class MensaNotificationTableViewCell: UITableViewCell {
             components.minute = 15
             time = Calendar.current.date(from: components) ?? Date()
         }
-        notificationTimeLabel.text = NSLocalizedString("dailyTime", comment: "") + formatter.string(from: time)
+        notificationTimeLabel.text = String(localized: "dailyTime") + formatter.string(from: time)
     }
 }

--- a/iOSApp/UniSaarTests/DirectoryViewControllerTests.swift
+++ b/iOSApp/UniSaarTests/DirectoryViewControllerTests.swift
@@ -82,7 +82,7 @@ class DirectoryViewControllerTests: XCTestCase {
         case .empty:
             let cell = viewControllerUnderTest.getHelpfulNumbersCell(indexPath: IndexPath(row: 0, section: 0))
             let config = cell.contentConfiguration as? UIListContentConfiguration
-            XCTAssertEqual(config?.text, NSLocalizedString("EmptyResults", comment: ""))
+            XCTAssertEqual(config?.text, String(localized: "EmptyResults"))
 
         case .none:
             break

--- a/iOSApp/UniSaarTests/EventCalanderViewControllerTests.swift
+++ b/iOSApp/UniSaarTests/EventCalanderViewControllerTests.swift
@@ -78,7 +78,7 @@ class EventCalanderViewControllerTests: XCTestCase {
             case .empty:
                 let cell = viewControllerUnderTest.tableView(viewControllerUnderTest.tableView, cellForRowAt: IndexPath(row: 0, section: 0))
                 let config = cell.contentConfiguration as? UIListContentConfiguration
-                XCTAssertEqual(config?.text, NSLocalizedString("EmptyEvents", comment: ""))
+                XCTAssertEqual(config?.text, String(localized: "EmptyEvents"))
             }
         }
     }

--- a/iOSApp/UniSaarTests/MensaViewControllerTests.swift
+++ b/iOSApp/UniSaarTests/MensaViewControllerTests.swift
@@ -73,7 +73,7 @@ class MensaViewControllerTests: XCTestCase {
         case .empty:
             let cell = viewControllerUnderTest.collectionView(viewControllerUnderTest.mensaCollectionView, cellForItemAt:
                 IndexPath(item: 0, section: 0)) as? ErrorCellCollectionViewCell
-            XCTAssertEqual(cell?.text, NSLocalizedString("emptyMenu", comment: "no menu"))
+            XCTAssertEqual(cell?.text, String(localized: "emptyMenu"))
         case .none:
             break
         }

--- a/iOSApp/UniSaarTests/MoreLinksViewControllerTests.swift
+++ b/iOSApp/UniSaarTests/MoreLinksViewControllerTests.swift
@@ -75,7 +75,7 @@ class MoreLinksViewControllerTests: XCTestCase {
         case .empty:
             let cell = viewControllerUnderTest.tableView(viewControllerUnderTest.tableView, cellForRowAt: IndexPath(row: 0, section: 0))
             let config = cell.contentConfiguration as? UIListContentConfiguration
-            XCTAssertEqual(config?.text, NSLocalizedString("EmptyResults", comment: ""))
+            XCTAssertEqual(config?.text, String(localized: "EmptyResults"))
 
         case .none:
             break

--- a/iOSApp/UniSaarTests/NewsFeedViewControllerTests.swift
+++ b/iOSApp/UniSaarTests/NewsFeedViewControllerTests.swift
@@ -75,7 +75,7 @@ class NewsFeedViewControllerTests: XCTestCase {
         case .empty:
             let cell = viewControllerUnderTest.tableView(viewControllerUnderTest.newsTable, cellForRowAt: IndexPath(row: 0, section: 0))
             let config = cell.contentConfiguration as? UIListContentConfiguration
-            XCTAssertEqual(config?.text, NSLocalizedString("EmptyNews", comment: ""))
+            XCTAssertEqual(config?.text, String(localized: "EmptyNews"))
 
         case .none:
             break


### PR DESCRIPTION
Replaces all 43 `NSLocalizedString("key", comment: "")` calls with the modern `String(localized: "key")` API  No behavior change, pure swift modernization


part of #32 work